### PR TITLE
Primary key

### DIFF
--- a/Crust/Mapper/CRMapper.swift
+++ b/Crust/Mapper/CRMapper.swift
@@ -15,12 +15,12 @@ extension Int : CRMappingKey { }
 
 public class MappingContext {
     public var json: JSONValue
-    public var object: Mappable
+    public var object: Any
     public private(set) var dir: MappingDirection
     public internal(set) var error: ErrorType?
     public internal(set) var parent: MappingContext? = nil
     
-    init(withObject object:Mappable, json: JSONValue, direction: MappingDirection) {
+    init(withObject object: Any, json: JSONValue, direction: MappingDirection) {
         self.dir = direction
         self.object = object
         self.json = json
@@ -28,7 +28,7 @@ public class MappingContext {
 }
 
 /// Method caller used to perform mappings.
-public struct CRMapper<T: Mappable, U: Mapping where U.MappedObject == T> {
+public struct CRMapper<T, U: Mapping where U.MappedObject == T> {
     
     public init() { }
     

--- a/Crust/Mapper/CRMapper.swift
+++ b/Crust/Mapper/CRMapper.swift
@@ -64,12 +64,15 @@ public extension Mapping {
         
         try self.checkForAdaptorBaseTypeConformance()
         
-        let primaryKeys = self.primaryKeys
+        guard let primaryKeys = self.primaryKeys else {
+            return nil
+        }
+        
         var keyValues = [ String : CVarArgType ]()
-        try primaryKeys.forEach {
-            let keyPath = $0.keyPath
+        try primaryKeys.forEach { primaryKey, jsonKey in
+            let keyPath = jsonKey.keyPath
             if let val = json[keyPath] {
-                keyValues[keyPath] = val.valuesAsNSObjects()
+                keyValues[primaryKey] = val.valuesAsNSObjects()
             } else {
                 let userInfo = [ NSLocalizedFailureReasonErrorKey : "Primary key of \(keyPath) does not exist in JSON but is expected from mapping \(Self.self)" ]
                 throw NSError(domain: CRMappingDomain, code: -1, userInfo: userInfo)

--- a/Crust/Mapper/MappingOperator.swift
+++ b/Crust/Mapper/MappingOperator.swift
@@ -65,7 +65,8 @@ public func mapField<T: JSONable, C: MappingContext where T == T.ConversionType>
             if let baseJSON = map.context.json[map.key] {
                 try mapFromJson(baseJSON, toField: &field)
             } else {
-                throw NSError(domain: CRMappingDomain, code: 0, userInfo: nil)
+                let userInfo = [ NSLocalizedFailureReasonErrorKey : "Could not find value in JSON \(map.context.json) from keyPath \(map.key)" ]
+                throw NSError(domain: CRMappingDomain, code: 0, userInfo: userInfo)
             }
         } catch let error as NSError {
             map.context.error = error
@@ -91,7 +92,8 @@ public func mapField<T: JSONable, C: MappingContext where T == T.ConversionType>
             if let baseJSON = map.context.json[map.key] {
                 try mapFromJson(baseJSON, toField: &field)
             } else {
-                throw NSError(domain: CRMappingDomain, code: 0, userInfo: nil)
+                let userInfo = [ NSLocalizedFailureReasonErrorKey : "Value not present in JSON \(map.context.json) from keyPath \(map.key)" ]
+                throw NSError(domain: CRMappingDomain, code: 0, userInfo: userInfo)
             }
         } catch let error as NSError {
             map.context.error = error
@@ -198,7 +200,8 @@ private func mapFromJson<T: JSONable where T.ConversionType == T>(json: JSONValu
     if let fromJson = T.fromJSON(json) {
         field = fromJson
     } else {
-        throw NSError(domain: CRMappingDomain, code: -1, userInfo: nil)
+        let userInfo = [ NSLocalizedFailureReasonErrorKey : "Conversion of JSON \(json) to type \(T.self) failed" ]
+        throw NSError(domain: CRMappingDomain, code: -1, userInfo: userInfo)
     }
 }
 
@@ -212,7 +215,8 @@ private func mapFromJson<T: JSONable where T.ConversionType == T>(json: JSONValu
     if let fromJson = T.fromJSON(json) {
         field = fromJson
     } else {
-        throw NSError(domain: CRMappingDomain, code: -1, userInfo: nil)
+        let userInfo = [ NSLocalizedFailureReasonErrorKey : "Conversion of JSON \(json) to type \(T.self) failed" ]
+        throw NSError(domain: CRMappingDomain, code: -1, userInfo: userInfo)
     }
 }
 

--- a/Crust/Mapper/MappingOperator.swift
+++ b/Crust/Mapper/MappingOperator.swift
@@ -24,11 +24,11 @@ public func <- <T: JSONable, C: MappingContext where T == T.ConversionType>(inou
 }
 
 // Map a Mappable.
-public func <- <T: Mappable, U: Mapping, C: MappingContext where U.MappedObject == T>(inout field: T, map:(key: KeyExtensions<U>, context: C)) -> C {
+public func <- <T, U: Mapping, C: MappingContext where U.MappedObject == T>(inout field: T, map:(key: KeyExtensions<U>, context: C)) -> C {
     return mapFieldWithMapping(&field, map: map)
 }
 
-public func <- <T: MappableJSONable, U: Transform, C: MappingContext where U.MappedObject == T, T == T.ConversionType>(inout field: T, map:(key: KeyExtensions<U>, context: C)) -> C {
+public func <- <T: JSONable, U: Transform, C: MappingContext where U.MappedObject == T, T == T.ConversionType>(inout field: T, map:(key: KeyExtensions<U>, context: C)) -> C {
     return mapFieldWithMapping(&field, map: map)
 }
 
@@ -39,11 +39,11 @@ public func <- <T: JSONable, C: MappingContext where T == T.ConversionType>(inou
     return mapField(&field, map: map)
 }
 
-public func <- <T: Mappable, U: Mapping, C: MappingContext where U.MappedObject == T>(inout field: T?, map:(key: KeyExtensions<U>, context: C)) -> C {
+public func <- <T, U: Mapping, C: MappingContext where U.MappedObject == T>(inout field: T?, map:(key: KeyExtensions<U>, context: C)) -> C {
     return mapFieldWithMapping(&field, map: map)
 }
 
-public func <- <T: MappableJSONable, U: Transform, C: MappingContext where U.MappedObject == T, T == T.ConversionType>(inout field: T?, map:(key: KeyExtensions<U>, context: C)) -> C {
+public func <- <T: JSONable, U: Transform, C: MappingContext where U.MappedObject == T, T == T.ConversionType>(inout field: T?, map:(key: KeyExtensions<U>, context: C)) -> C {
     return mapFieldWithMapping(&field, map: map)
 }
 
@@ -102,7 +102,7 @@ public func mapField<T: JSONable, C: MappingContext where T == T.ConversionType>
 }
 
 // Mappable.
-public func mapFieldWithMapping<T: Mappable, U: Mapping, C: MappingContext where U.MappedObject == T>(inout field: T, map:(key: KeyExtensions<U>, context: C)) -> C {
+public func mapFieldWithMapping<T, U: Mapping, C: MappingContext where U.MappedObject == T>(inout field: T, map:(key: KeyExtensions<U>, context: C)) -> C {
     
     guard map.context.error == nil else {
         return map.context
@@ -135,7 +135,7 @@ public func mapFieldWithMapping<T: Mappable, U: Mapping, C: MappingContext where
 }
 
 // TODO: Maybe we can just make Optional: Mappable and then this redudancy can safely go away...
-public func mapFieldWithMapping<T: Mappable, U: Mapping, C: MappingContext where U.MappedObject == T>(inout field: T?, map:(key: KeyExtensions<U>, context: C)) -> C {
+public func mapFieldWithMapping<T, U: Mapping, C: MappingContext where U.MappedObject == T>(inout field: T?, map:(key: KeyExtensions<U>, context: C)) -> C {
     
     guard map.context.error == nil else {
         return map.context
@@ -180,7 +180,7 @@ private func mapToJson<T: JSONable where T == T.ConversionType>(var json: JSONVa
     return json
 }
 
-private func mapToJson<T: Mappable, U: Mapping where U.MappedObject == T>(var json: JSONValue, fromField field: T?, viaKey key: CRMappingKey, mapping: U) throws -> JSONValue {
+private func mapToJson<T, U: Mapping where U.MappedObject == T>(var json: JSONValue, fromField field: T?, viaKey key: CRMappingKey, mapping: U) throws -> JSONValue {
     
     guard let field = field else {
         json[key] = .JSONNull()
@@ -216,13 +216,13 @@ private func mapFromJson<T: JSONable where T.ConversionType == T>(json: JSONValu
     }
 }
 
-private func mapFromJson<T: Mappable, U: Mapping where U.MappedObject == T>(json: JSONValue, inout toField field: T, mapping: U, context: MappingContext) throws {
+private func mapFromJson<T, U: Mapping where U.MappedObject == T>(json: JSONValue, inout toField field: T, mapping: U, context: MappingContext) throws {
     
     let mapper = CRMapper<T, U>()
     field = try mapper.mapFromJSONToExistingObject(json, mapping: mapping, parentContext: context)
 }
 
-private func mapFromJson<T: Mappable, U: Mapping where U.MappedObject == T>(json: JSONValue, inout toField field: T?, mapping: U, context: MappingContext) throws {
+private func mapFromJson<T, U: Mapping where U.MappedObject == T>(json: JSONValue, inout toField field: T?, mapping: U, context: MappingContext) throws {
     
     if case .JSONNull = json {
         field = nil
@@ -235,12 +235,12 @@ private func mapFromJson<T: Mappable, U: Mapping where U.MappedObject == T>(json
 
 // MARK: - RangeReplaceableCollectionType (Array and Realm List follow this protocol)
 
-public func <- <T: Mappable, U: Mapping, V: RangeReplaceableCollectionType, C: MappingContext where U.MappedObject == T, V.Generator.Element == T, T: Equatable>(inout field: V, map:(key: KeyExtensions<U>, context: C)) -> C {
+public func <- <T, U: Mapping, V: RangeReplaceableCollectionType, C: MappingContext where U.MappedObject == T, V.Generator.Element == T, T: Equatable>(inout field: V, map:(key: KeyExtensions<U>, context: C)) -> C {
     
     return mapField(&field, map: map)
 }
 
-public func mapField<T: Mappable, U: Mapping, V: RangeReplaceableCollectionType, C: MappingContext where U.MappedObject == T, V.Generator.Element == T, T: Equatable>(inout field: V, map:(key: KeyExtensions<U>, context: C)) -> C {
+public func mapField<T, U: Mapping, V: RangeReplaceableCollectionType, C: MappingContext where U.MappedObject == T, V.Generator.Element == T, T: Equatable>(inout field: V, map:(key: KeyExtensions<U>, context: C)) -> C {
     
     guard map.context.error == nil else {
         return map.context
@@ -268,7 +268,7 @@ public func mapField<T: Mappable, U: Mapping, V: RangeReplaceableCollectionType,
     return map.context
 }
 
-private func mapToJson<T: Mappable, U: Mapping, V: RangeReplaceableCollectionType where U.MappedObject == T, V.Generator.Element == T>(var json: JSONValue, fromField field: V, viaKey key: CRMappingKey, mapping: U) throws -> JSONValue {
+private func mapToJson<T, U: Mapping, V: RangeReplaceableCollectionType where U.MappedObject == T, V.Generator.Element == T>(var json: JSONValue, fromField field: V, viaKey key: CRMappingKey, mapping: U) throws -> JSONValue {
     
     let results = try field.map {
         try CRMapper<T, U>().mapFromObjectToJSON($0, mapping: mapping)
@@ -278,7 +278,7 @@ private func mapToJson<T: Mappable, U: Mapping, V: RangeReplaceableCollectionTyp
     return json
 }
 
-private func mapFromJson<T: Mappable, U: Mapping, V: RangeReplaceableCollectionType where U.MappedObject == T, V.Generator.Element == T, T: Equatable>(json: JSONValue, inout toField field: V, mapping: U, context: MappingContext, allowDuplicates: Bool) throws {
+private func mapFromJson<T, U: Mapping, V: RangeReplaceableCollectionType where U.MappedObject == T, V.Generator.Element == T, T: Equatable>(json: JSONValue, inout toField field: V, mapping: U, context: MappingContext, allowDuplicates: Bool) throws {
     
     if case .JSONArray(let xs) = json {
         let mapper = CRMapper<T, U>()

--- a/Crust/Mapper/MappingProtocols.swift
+++ b/Crust/Mapper/MappingProtocols.swift
@@ -15,7 +15,7 @@ public protocol Mapping {
     typealias AdaptorKind: Adaptor
     
     var adaptor: AdaptorKind { get }
-    var primaryKeys: Array<CRMappingKey> { get }
+    var primaryKeys: Dictionary<String, CRMappingKey>? { get }
     
     func mapping(inout tomap: MappedObject, context: MappingContext)
 }

--- a/Crust/Mapper/MappingProtocols.swift
+++ b/Crust/Mapper/MappingProtocols.swift
@@ -65,7 +65,8 @@ public class JSONableMapping<T: JSONable where T.ConversionType: AnyMappable> : 
         if let obj = T.fromJSON(json) {
             return obj
         } else {
-            throw NSError(domain: CRMappingDomain, code: -1, userInfo: nil)
+            let userInfo = [ NSLocalizedFailureReasonErrorKey : "Type of \(T.self) could not convert JSON \(json)" ]
+            throw NSError(domain: CRMappingDomain, code: -1, userInfo: userInfo)
         }
     }
     

--- a/Crust/Mapper/MappingProtocols.swift
+++ b/Crust/Mapper/MappingProtocols.swift
@@ -58,6 +58,22 @@ public extension Transform {
     }
 }
 
+public class JSONableMapping<T: JSONable where T.ConversionType: AnyMappable> : Transform {
+    public typealias MappedObject = T.ConversionType
+    
+    public func fromJSON(json: JSONValue) throws -> MappedObject {
+        if let obj = T.fromJSON(json) {
+            return obj
+        } else {
+            throw NSError(domain: CRMappingDomain, code: -1, userInfo: nil)
+        }
+    }
+    
+    public func toJSON(obj: MappedObject) -> JSONValue {
+        return T.toJSON(obj)
+    }
+}
+
 public enum KeyExtensions<T: Mapping> : CRMappingKey {
     case Mapping(CRMappingKey, T)
     indirect case MappingOptions(KeyExtensions, CRMappingOptions)

--- a/Crust/Mapper/MappingProtocols.swift
+++ b/Crust/Mapper/MappingProtocols.swift
@@ -28,7 +28,7 @@ public protocol Adaptor {
     func mappingEnded() throws
     func mappingErrored(error: ErrorType)
     
-    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> ResultsType
+    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> ResultsType?
     func createObject(objType: BaseType.Type) throws -> BaseType
     func deleteObject(obj: BaseType) throws
     func saveObjects(objects: [ BaseType ]) throws

--- a/Crust/Mapper/MappingProtocols.swift
+++ b/Crust/Mapper/MappingProtocols.swift
@@ -10,12 +10,8 @@ public struct CRMappingOptions : OptionSetType {
     public static let AllowDuplicatesInCollection = CRMappingOptions(rawValue: 1)
 }
 
-public typealias MappableJSONable = protocol<Mappable, JSONable>
-
-public protocol Mappable { }
-
 public protocol Mapping {
-    typealias MappedObject: Mappable
+    typealias MappedObject
     typealias AdaptorKind: Adaptor
     
     var adaptor: AdaptorKind { get }
@@ -55,23 +51,6 @@ public extension Transform {
         case .ToJSON:
             context.json = self.toJSON(tomap)
         }
-    }
-}
-
-public class JSONableMapping<T: JSONable where T.ConversionType: AnyMappable> : Transform {
-    public typealias MappedObject = T.ConversionType
-    
-    public func fromJSON(json: JSONValue) throws -> MappedObject {
-        if let obj = T.fromJSON(json) {
-            return obj
-        } else {
-            let userInfo = [ NSLocalizedFailureReasonErrorKey : "Type of \(T.self) could not convert JSON \(json)" ]
-            throw NSError(domain: CRMappingDomain, code: -1, userInfo: userInfo)
-        }
-    }
-    
-    public func toJSON(obj: MappedObject) -> JSONValue {
-        return T.toJSON(obj)
     }
 }
 

--- a/Crust/Utilities/AnyAdaptor.swift
+++ b/Crust/Utilities/AnyAdaptor.swift
@@ -42,7 +42,7 @@ public extension AnyAdaptor {
     func mappingEnded() throws { }
     func mappingErrored(error: ErrorType) { }
     
-    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> Array<BaseType> {
+    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> Array<BaseType>? {
         return Array<BaseType>()
     }
     

--- a/Crust/Utilities/AnyAdaptor.swift
+++ b/Crust/Utilities/AnyAdaptor.swift
@@ -15,8 +15,8 @@ public extension AnyMapping {
         return AnyAdaptorImp<MappedObject>()
     }
     
-    var primaryKeys: Array<CRMappingKey> {
-        return []
+    var primaryKeys: Dictionary<String, CRMappingKey>? {
+        return nil
     }
 }
 
@@ -43,7 +43,7 @@ public extension AnyAdaptor {
     func mappingErrored(error: ErrorType) { }
     
     func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> Array<BaseType>? {
-        return Array<BaseType>()
+        return nil
     }
     
     func createObject(objType: BaseType.Type) throws -> BaseType {

--- a/Crust/Utilities/AnyAdaptor.swift
+++ b/Crust/Utilities/AnyAdaptor.swift
@@ -1,5 +1,5 @@
 /// `MappedObject` type constraint required in `AnyMapping`.
-public protocol AnyMappable : Mappable {
+public protocol AnyMappable {
     init()
 }
 

--- a/CrustTests/CRMapperTests.swift
+++ b/CrustTests/CRMapperTests.swift
@@ -25,7 +25,7 @@ class MockMap : Mapping, Adaptor {
     func mappingEnded() throws { }
     func mappingErrored(error: ErrorType) { }
     
-    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> ResultsType { return [ ] }
+    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> ResultsType? { return [ ] }
     func createObject(objType: BaseType.Type) -> BaseType { return self }
     func deleteObject(obj: BaseType) throws { }
     func saveObjects(objects: [ BaseType ]) throws { }

--- a/CrustTests/CRMapperTests.swift
+++ b/CrustTests/CRMapperTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Crust
 import JSONValueRX
 
-class MockMap : Mappable, Mapping, Adaptor {
+class MockMap : Mapping, Adaptor {
     typealias BaseType = MockMap
     typealias ResultsType = Array<MockMap>
     

--- a/CrustTests/CRMapperTests.swift
+++ b/CrustTests/CRMapperTests.swift
@@ -13,8 +13,8 @@ class MockMap : Mapping, Adaptor {
     var adaptor: MockMap {
         return self
     }
-    var primaryKeys: Array<CRMappingKey> {
-        return [ ]
+    var primaryKeys: Dictionary<String, CRMappingKey>? {
+        return nil
     }
     
     func mapping(inout tomap: MockMap, context: MappingContext) {
@@ -25,7 +25,7 @@ class MockMap : Mapping, Adaptor {
     func mappingEnded() throws { }
     func mappingErrored(error: ErrorType) { }
     
-    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> ResultsType? { return [ ] }
+    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> ResultsType? { return nil }
     func createObject(objType: BaseType.Type) -> BaseType { return self }
     func deleteObject(obj: BaseType) throws { }
     func saveObjects(objects: [ BaseType ]) throws { }

--- a/CrustTests/Company.swift
+++ b/CrustTests/Company.swift
@@ -17,8 +17,8 @@ extension Company: AnyMappable { }
 class CompanyMapping : Mapping {
     
     var adaptor: MockAdaptor<Company>
-    var primaryKeys: Array<CRMappingKey> {
-        return [ "uuid" ]
+    var primaryKeys: Dictionary<String, CRMappingKey>? {
+        return [ "uuid" : "data.uuid" ]
     }
     
     required init(adaptor: MockAdaptor<Company>) {
@@ -30,7 +30,7 @@ class CompanyMapping : Mapping {
         
         tomap.employees             <- KeyExtensions.Mapping("employees", employeeMapping) >*<
         tomap.founder               <- .Mapping("founder", employeeMapping) >*<
-        tomap.uuid                  <- "uuid" >*<
+        tomap.uuid                  <- "data.uuid" >*<
         tomap.name                  <- "name" >*<
         tomap.foundingDate          <- "data.founding_date"  >*<
         tomap.pendingLawsuits       <- "data.lawsuits.pending"  >*<
@@ -46,7 +46,7 @@ class CompanyMappingWithDupes : CompanyMapping {
         
         tomap.employees             <- KeyExtensions.MappingOptions(mappingExtension, [ .AllowDuplicatesInCollection ]) >*<
         tomap.founder               <- .Mapping("founder", employeeMapping) >*<
-        tomap.uuid                  <- "uuid" >*<
+        tomap.uuid                  <- "data.uuid" >*<
         tomap.name                  <- "name" >*<
         tomap.foundingDate          <- "data.founding_date"  >*<
         tomap.pendingLawsuits       <- "data.lawsuits.pending"  >*<

--- a/CrustTests/CompanyStub.swift
+++ b/CrustTests/CompanyStub.swift
@@ -27,11 +27,11 @@ class CompanyStub {
     func generateJsonObject() -> Dictionary<String, AnyObject> {
         let founder = self.founder?.generateJsonObject()
         return [
-            "uuid" : uuid,
             "name" : name,
             "employees" : employees.map { $0.generateJsonObject() } as NSArray,
             "founder" : founder == nil ? NSNull() : founder! as NSDictionary,
             "data" : [
+                "uuid" : uuid,
                 "lawsuits" : [
                     "pending" : pendingLawsuits
                 ]

--- a/CrustTests/Employee.swift
+++ b/CrustTests/Employee.swift
@@ -18,8 +18,8 @@ extension Employee: AnyMappable { }
 class EmployeeMapping : MockMapping {
     
     var adaptor: MockAdaptor<Employee>
-    var primaryKeys: Array<CRMappingKey> {
-        return [ "uuid" ]
+    var primaryKeys: Dictionary<String, CRMappingKey>? {
+        return [ "uuid" : "uuid" ]
     }
     
     required init(adaptor: MockAdaptor<Employee>) {

--- a/CrustTests/Mocks.swift
+++ b/CrustTests/Mocks.swift
@@ -8,7 +8,7 @@ class MockAdaptor<T: AnyMappable> : Adaptor {
     func mappingEnded() throws { }
     func mappingErrored(error: ErrorType) { }
     
-    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> ResultsType { return [] }
+    func fetchObjectsWithType(type: BaseType.Type, keyValues: Dictionary<String, CVarArgType>) -> ResultsType? { return [] }
     func createObject(objType: BaseType.Type) throws -> BaseType { return objType.init() }
     func deleteObject(obj: BaseType) throws { }
     func saveObjects(objects: [ BaseType ]) throws { }

--- a/CrustTests/TransformTests.swift
+++ b/CrustTests/TransformTests.swift
@@ -70,7 +70,6 @@ class User {
     var name: String? = nil
     var surname: String? = nil
     var birthDate: NSDate? = nil
-    
 }
 
 extension User: AnyMappable { }
@@ -78,8 +77,8 @@ extension User: AnyMappable { }
 class UserMapping: Mapping {
     
     var adaptor: MockAdaptor<User>
-    var primaryKeys: Array<CRMappingKey> {
-        return [ "data.id_hash" ]
+    var primaryKeys: Dictionary<String, CRMappingKey>? {
+        return [ "identifier" : "data.id_hash" ]
     }
     
     required init(adaptor: MockAdaptor<User>) {


### PR DESCRIPTION
Fixes a bunch of issues with `primaryKeys`.

First off, `primaryKeys`previously assumed that the keypath from the JSON's primary key to the `MappedObject`'s primary key were identical which isn't always the case. It's been adjusted to the following example format which defines both the key in the Object and the key in the JSON:
```swift
var primaryKeys: Dictionary<String, CRMappingKey>? {
    return [ "identifier" : "data.id_hash" ]
}
```

Second, `Mappable` has mostly turned into a useless protocol so I'm just removing it altogether. This was driven by a different change I originally had in mind for `primaryKeys`, that didn't actually pan out, but did demonstrate that `Mappable` acts more of an obstacle than anything. I also included some general code cleanup.