### PR TITLE
Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: objective-c
 osx_image: xcode8.3
 xcode_workspace: Crust.xcworkspace
 xcode_scheme: Crust
-xcode_sdk: iphonesimulator10.1
+xcode_sdk: iphonesimulator10.3
 script:
  - set -o pipefail
  - xcodebuild -version
  - xcodebuild -showsdks
- - xcodebuild -workspace Crust.xcworkspace -scheme Crust -sdk iphonesimulator -destination "OS=10.1,name=iPhone 7" ONLY_ACTIVE_ARCH=NO build test
+ - xcodebuild -workspace Crust.xcworkspace -scheme Crust -sdk iphonesimulator -destination "OS=10.3,name=iPhone 7" ONLY_ACTIVE_ARCH=NO build test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode8.3
 xcode_workspace: Crust.xcworkspace
 xcode_scheme: Crust
 xcode_sdk: iphonesimulator10.1

--- a/Crust/Mapper/MappingOperator.swift
+++ b/Crust/Mapper/MappingOperator.swift
@@ -9,10 +9,6 @@ public func >*< <T, U>(left: T, right: U) -> (T, U) {
     return (left, right)
 }
 
-public func >*< <T: JSONKeypath, U>(left: T, right: U) -> (JSONKeypath, U) {
-    return (left, right)
-}
-
 // MARK: - Map value operator definition
 
 infix operator <- : AssignmentPrecedence

--- a/Crust/Mapper/MappingOperator.swift
+++ b/Crust/Mapper/MappingOperator.swift
@@ -271,10 +271,18 @@ private func map<T, M: Mapping>(from json: JSONValue, to field: inout T?, using 
 
 // MARK: - RangeReplaceableCollectionType (Array and Realm List follow this protocol).
 
+/// This handles the case where our Collection contains Equatable objects, and thus can be uniqued during insertion and deletion.
 @discardableResult
 public func <- <T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>(field: inout RRC, binding:(key: Binding<M>, context: MC)) -> MC where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject, T: Equatable {
     
     return map(toCollection: &field, using: binding)
+}
+
+/// This is for Collections with non-Equatable objects.
+@discardableResult
+public func <- <T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>(field: inout RRC, binding:(key: Binding<M>, context: MC)) -> MC where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject {
+    
+    return map(toCollection: &field, using: binding, elementEquality: nil, indexOf: nil, fieldContains: nil)
 }
 
 private func map<T, M: Mapping, S: Sequence>(
@@ -296,7 +304,30 @@ private func map<T, M: Mapping, S: Sequence>(
 }
 
 @discardableResult
-public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>(toCollection field: inout RRC, using binding:(key: Binding<M>, context: MC)) -> MC where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject, T: Equatable {
+public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>
+    (toCollection field: inout RRC,
+     using binding:(key: Binding<M>, context: MC))
+    -> MC
+    where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject, T: Equatable {
+        
+        let equality: (T) -> (T) -> Bool = { obj in
+            { compared in
+                obj == compared
+            }
+        }
+        
+        return map(toCollection: &field, using: binding, elementEquality: equality, indexOf: RRC.index(of:), fieldContains: RRC.contains)
+}
+
+@discardableResult
+public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>
+    (toCollection field: inout RRC,
+     using binding:(key: Binding<M>, context: MC),
+     elementEquality: ((T) -> (T) -> Bool)?,
+     indexOf: ((RRC) -> (T) -> RRC.Index?)?,
+     fieldContains: ((RRC) -> (T) -> Bool)?)
+    -> MC
+    where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject {
     
     do {
         switch binding.context.dir {
@@ -306,9 +337,11 @@ public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollecti
             
         case .fromJSON:
             let fieldCopy = field
-            let (newObjects, _) = try mapFromJsonToSequence(map: binding) {
-                fieldCopy.contains($0)
-            }
+            let contains = fieldContains?(fieldCopy)
+            let (newObjects, _) = try mapFromJsonToSequence(
+                map: binding,
+                newObjectsContains: elementEquality ?? { _ in { _ in false } },
+                fieldContains: contains ?? { _ in false })
             
             switch binding.key.collectionUpdatePolicy.insert {
             case .append:
@@ -319,7 +352,7 @@ public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollecti
                 
                 if let deletion = deletionBlock {
                     newObjects.forEach {
-                        if let index = orphans.index(of: $0) {
+                        if let index = indexOf?(orphans)($0) {
                             orphans.remove(at: index)
                         }
                     }
@@ -347,9 +380,10 @@ public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollecti
 // Gets all newly mapped data and returns it in an array, caller can decide to append and what-not.
 private func mapFromJsonToSequence<T, M: Mapping, MC: MappingContext>(
     map:(key: Binding<M>, context: MC),
+    newObjectsContains: @escaping (T) -> (T) -> Bool,
     fieldContains: (T) -> Bool)
     throws -> (newObjects: [T], context: MC)
-    where M.MappedObject == T, T: Equatable {
+    where M.MappedObject == T {
     
         guard map.context.error == nil else {
             throw map.context.error!
@@ -367,6 +401,7 @@ private func mapFromJsonToSequence<T, M: Mapping, MC: MappingContext>(
             newObjects = try generateNewValues(fromJsonArray: json,
                                      with: updatePolicy,
                                      using: mapping,
+                                     newObjectsContains: newObjectsContains,
                                      fieldContains: fieldContains,
                                      context: map.context)
         }
@@ -374,6 +409,7 @@ private func mapFromJsonToSequence<T, M: Mapping, MC: MappingContext>(
             newObjects = try generateNewValues(fromJsonArray: baseJSON,
                                      with: updatePolicy,
                                      using: mapping,
+                                     newObjectsContains: newObjectsContains,
                                      fieldContains: fieldContains,
                                      context: map.context)
         }
@@ -389,10 +425,11 @@ private func generateNewValues<T, M: Mapping>(
     fromJsonArray json: JSONValue,
     with updatePolicy: CollectionUpdatePolicy<M.MappedObject>,
     using mapping: M,
+    newObjectsContains: @escaping (T) -> (T) -> Bool,
     fieldContains: (T) -> Bool,
     context: MappingContext)
     throws -> [T]
-    where M.MappedObject == T, T: Equatable {
+    where M.MappedObject == T {
     
         guard case .array(let jsonArray) = json else {
             let userInfo = [ NSLocalizedFailureReasonErrorKey : "Trying to map json of type \(type(of: json)) to Collection of <\(T.self)>" ]
@@ -404,7 +441,7 @@ private func generateNewValues<T, M: Mapping>(
         var newObjects = [T]()
         
         let isUnique = { (obj: T, newObjects: [T], fieldContains: (T) -> Bool) -> Bool in
-            let newObjectsContainsObj = newObjects.contains(obj)
+            let newObjectsContainsObj = newObjects.contains(where: newObjectsContains(obj))
             
             switch updatePolicy.insert {
             case .replace(_):

--- a/Crust/Mapper/MappingOperator.swift
+++ b/Crust/Mapper/MappingOperator.swift
@@ -20,13 +20,23 @@ infix operator <- : AssignmentPrecedence
 // Map with a key path.
 
 @discardableResult
-public func <- <T: JSONable, MC: MappingContext>(field: inout T, keyPath:(key: JSONKeypath, context: MC)) -> MC where T == T.ConversionType {
-    return map(to: &field, via: keyPath)
+public func <- <T: JSONable, MC: MappingContext>(field: inout T, keyPath:(key: String, context: MC)) -> MC where T == T.ConversionType {
+    return map(to: &field, via: (keyPath.key as JSONKeypath, keyPath.context))
 }
 
 @discardableResult
-public func <- <T: JSONable, MC: MappingContext>(field: inout T?, keyPath:(key: JSONKeypath, context: MC)) -> MC where T == T.ConversionType {
-    return map(to: &field, via: keyPath)
+public func <- <T: JSONable, MC: MappingContext>(field: inout T?, keyPath:(key: String, context: MC)) -> MC where T == T.ConversionType {
+    return map(to: &field, via: (keyPath.key as JSONKeypath, keyPath.context))
+}
+
+@discardableResult
+public func <- <T: JSONable, MC: MappingContext>(field: inout T, keyPath:(key: Int, context: MC)) -> MC where T == T.ConversionType {
+    return map(to: &field, via: (keyPath.key as JSONKeypath, keyPath.context))
+}
+
+@discardableResult
+public func <- <T: JSONable, MC: MappingContext>(field: inout T?, keyPath:(key: Int, context: MC)) -> MC where T == T.ConversionType {
+    return map(to: &field, via: (keyPath.key as JSONKeypath, keyPath.context))
 }
 
 // Map with a generic binding.

--- a/Crust/Mapper/MappingOperator.swift
+++ b/Crust/Mapper/MappingOperator.swift
@@ -135,7 +135,7 @@ public func map<T, M: Mapping, MC: MappingContext>(to field: inout T, using bind
             // TODO: again, need to allow for `nil` keypaths.
             if let baseJSON: JSONValue = {
                 let key = binding.key
-                let json = binding.context.json[binding.key]
+                let json = binding.context.json[binding.key.keyPath]
                 if json == nil && key.keyPath == "" {
                     return binding.context.json
                 }
@@ -174,7 +174,7 @@ public func map<T, M: Mapping, MC: MappingContext>(to field: inout T?, using bin
             let json = binding.context.json
             try binding.context.json = Crust.map(to: json, from: field, via: key, using: mapping)
         case .fromJSON:
-            if let baseJSON = binding.context.json[binding.key] {
+            if let baseJSON = binding.context.json[binding.key.keyPath] {
                 try map(from: baseJSON, to: &field, using: mapping, context: binding.context)
             }
             else {
@@ -296,7 +296,7 @@ public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollecti
         switch binding.context.dir {
         case .toJSON:
             let json = binding.context.json
-            try binding.context.json = Crust.map(to: json, from: field, via: binding.key, using: binding.key.mapping)
+            try binding.context.json = Crust.map(to: json, from: field, via: binding.key.keyPath, using: binding.key.mapping)
             
         case .fromJSON:
             let fieldCopy = field
@@ -353,7 +353,7 @@ private func mapFromJsonToSequence<T, M: Mapping, MC: MappingContext>(
         var newObjects: [T] = []
         
         let json = map.context.json
-        let baseJSON = json[map.key]
+        let baseJSON = json[map.key.keyPath]
         let updatePolicy = map.key.collectionUpdatePolicy
         
         // TODO: Stupid hack for empty string keypaths. Fix by allowing `nil` keyPath.

--- a/Crust/Mapper/MappingProtocols.swift
+++ b/Crust/Mapper/MappingProtocols.swift
@@ -9,7 +9,7 @@ public enum CollectionInsertionMethod<Element> {
 public typealias CollectionUpdatePolicy<Element> =
     (insert: CollectionInsertionMethod<Element>, unique: Bool)
 
-public enum Binding<M: Mapping>: Keypath {
+public enum Binding<M: Mapping> {
     
     case mapping(Keypath, M)
     case collectionMapping(Keypath, M, CollectionUpdatePolicy<M.MappedObject>)

--- a/CrustTests/Company.swift
+++ b/CrustTests/Company.swift
@@ -28,7 +28,7 @@ class CompanyMapping: Mapping {
     func mapping(toMap: inout Company, context: MappingContext) {
         let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
         
-        toMap.employees             <- Binding.mapping("employees", employeeMapping) >*<
+        toMap.employees             <- .mapping("employees", employeeMapping) >*<
         toMap.founder               <- .mapping("founder", employeeMapping) >*<
         toMap.uuid                  <- "data.uuid" >*<
         toMap.name                  <- "name" >*<
@@ -43,7 +43,7 @@ class CompanyMappingWithDupes: CompanyMapping {
     override func mapping(toMap: inout Company, context: MappingContext) {
         let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
         
-        toMap.employees             <- Binding.collectionMapping("employees", employeeMapping, (.append, true)) >*<
+        toMap.employees             <- .collectionMapping("employees", employeeMapping, (.append, true)) >*<
         toMap.founder               <- .mapping("founder", employeeMapping) >*<
         toMap.uuid                  <- "data.uuid" >*<
         toMap.name                  <- "name" >*<

--- a/CrustTests/Employee.swift
+++ b/CrustTests/Employee.swift
@@ -1,6 +1,6 @@
 import Crust
 
-class Employee: Equatable {
+class Employee {
     required init() { }
     
     var employer: Company?
@@ -10,10 +10,6 @@ class Employee: Equatable {
     var salary: Int = 0
     var isEmployeeOfMonth: Bool = false
     var percentYearlyRaise: Double = 0.0
-    
-    static func ==(lhs: Employee, rhs: Employee) -> Bool {
-        return lhs.uuid == rhs.uuid
-    }
 }
 
 extension Employee: AnyMappable { }

--- a/CrustTests/Employee.swift
+++ b/CrustTests/Employee.swift
@@ -1,7 +1,6 @@
 import Crust
 
-class Employee {
-    
+class Employee: Equatable {
     required init() { }
     
     var employer: Company?
@@ -11,6 +10,10 @@ class Employee {
     var salary: Int = 0
     var isEmployeeOfMonth: Bool = false
     var percentYearlyRaise: Double = 0.0
+    
+    static func ==(lhs: Employee, rhs: Employee) -> Bool {
+        return lhs.uuid == rhs.uuid
+    }
 }
 
 extension Employee: AnyMappable { }

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ func mapping(inout toMap: Company, context: MappingContext) {
 * replace and/or delete objects
 * append objects to the collection
 * unique objects in collection (remove duplicates)
+  * uniquing on works if the `Element` of the collection being mapped to follows `Equatable`.
+  * If the `Element` does not follow `Equatable` its is also possible to use `map(toCollection field:, using binding:, elementEquality:, indexOf:, contains:)` to provide explicit comparison / indexing functions required for uniquing.
 
 By default using `.mapping` will `(insert: .append, unique: true)`.
 

--- a/RealmCrustTests/CollectionMappingTests.swift
+++ b/RealmCrustTests/CollectionMappingTests.swift
@@ -47,7 +47,7 @@ class CollectionMappingTests: RealmMappingTest {
         class CompanyMappingAppendUnique: CompanyMapping {
             override func mapping(toMap: inout Company, context: MappingContext) {
                 let employeeMapping = EmployeeMapping(adapter: self.adapter)
-                map(toRLMArray: toMap.employees, using: (Binding.collectionMapping("employees", employeeMapping, (.append, true)), context))
+                map(toRLMArray: toMap.employees, using: (.collectionMapping("employees", employeeMapping, (.append, true)), context))
             }
         }
         
@@ -94,7 +94,7 @@ class CollectionMappingTests: RealmMappingTest {
             override func mapping(toMap: inout Company, context: MappingContext) {
                 let employeeMapping = EmployeeMapping(adapter: self.adapter)
                 map(toRLMArray: toMap.employees,
-                    using: (Binding.collectionMapping("employees", employeeMapping, (.replace(delete: nil), true)), context))
+                    using: (.collectionMapping("employees", employeeMapping, (.replace(delete: nil), true)), context))
             }
         }
         
@@ -135,7 +135,7 @@ class CollectionMappingTests: RealmMappingTest {
             override func mapping(toMap: inout Company, context: MappingContext) {
                 let employeeMapping = EmployeeMapping(adapter: self.adapter)
                 map(toRLMArray: toMap.employees,
-                    using: (Binding.collectionMapping("employees", employeeMapping, (.replace(delete: { $0 }), true)), context))
+                    using: (.collectionMapping("employees", employeeMapping, (.replace(delete: { $0 }), true)), context))
             }
         }
         

--- a/RealmCrustTests/CollectionMappingTests.swift
+++ b/RealmCrustTests/CollectionMappingTests.swift
@@ -47,7 +47,7 @@ class CollectionMappingTests: RealmMappingTest {
         class CompanyMappingAppendUnique: CompanyMapping {
             override func mapping(toMap: inout Company, context: MappingContext) {
                 let employeeMapping = EmployeeMapping(adapter: self.adapter)
-                map(toRLMArray: toMap.employees, using: (.collectionMapping("employees", employeeMapping, (.append, true)), context))
+                map(toRLMArray: toMap.employees, using: (Binding.collectionMapping("employees", employeeMapping, (.append, true)), context))
             }
         }
         

--- a/RealmCrustTests/Company.swift
+++ b/RealmCrustTests/Company.swift
@@ -16,7 +16,7 @@ public class CompanyMapping : RealmMapping {
     public func mapping(toMap: inout Company, context: MappingContext) {
         let employeeMapping = EmployeeMapping(adapter: self.adapter)
         
-        toMap.employees             <- (Binding.collectionMapping("employees", employeeMapping, (.append, true)), context)
+        toMap.employees             <- (.collectionMapping("employees", employeeMapping, (.append, true)), context)
         toMap.founder               <- .mapping("founder", employeeMapping) >*< context
         toMap.name                  <- "name" >*<
         toMap.foundingDate          <- "data.founding_date"  >*<
@@ -30,7 +30,7 @@ public class CompanyMappingWithDupes : CompanyMapping {
     public override func mapping(toMap: inout Company, context: MappingContext) {
         let employeeMapping = EmployeeMapping(adapter: self.adapter)
         
-        toMap.employees <- (Binding.collectionMapping("employees", employeeMapping, (.append, false)), context)
+        toMap.employees <- (.collectionMapping("employees", employeeMapping, (.append, false)), context)
         toMap.founder               <- .mapping("founder", employeeMapping) >*<
         toMap.uuid                  <- "data.uuid" >*<
         toMap.name                  <- "name" >*<

--- a/RealmCrustTests/Company.swift
+++ b/RealmCrustTests/Company.swift
@@ -16,7 +16,7 @@ public class CompanyMapping : RealmMapping {
     public func mapping(toMap: inout Company, context: MappingContext) {
         let employeeMapping = EmployeeMapping(adapter: self.adapter)
         
-        toMap.employees             <- (.collectionMapping("employees", employeeMapping, (.append, true)), context)
+        toMap.employees             <- (Binding.collectionMapping("employees", employeeMapping, (.append, true)), context)
         toMap.founder               <- .mapping("founder", employeeMapping) >*< context
         toMap.name                  <- "name" >*<
         toMap.foundingDate          <- "data.founding_date"  >*<

--- a/RealmCrustTests/PrimaryKeyTests.swift
+++ b/RealmCrustTests/PrimaryKeyTests.swift
@@ -17,7 +17,7 @@ class PrimaryObj1Mapping : RealmMapping {
     func mapping(toMap: inout PrimaryObj1, context: MappingContext) {
         let obj2Mapping = PrimaryObj2Mapping(adapter: self.adapter)
         
-        map(toRLMArray: toMap.class2s, using: (Binding.mapping("class2s", obj2Mapping), context))
+        map(toRLMArray: toMap.class2s, using: (.mapping("class2s", obj2Mapping), context))
         toMap.uuid          <- "data.uuid" >*<
         context
     }

--- a/RealmCrustTests/RealmMappings.swift
+++ b/RealmCrustTests/RealmMappings.swift
@@ -98,6 +98,8 @@ public class RealmAdapter: Adapter {
         return type.sanitizeValue(value, fromProperty: property, realm: self.realm)
     }
     
+    // TODO: This should throw and we should check that the primary key's type and value's sanitized type match.
+    // Otherwise we get an exception from Realm here.
     public func fetchObjects(type: RLMObject.Type, primaryKeyValues: [[String : CVarArg]], isMapping: Bool) -> ResultsType? {
         
         var totalPredicate = [NSPredicate]()
@@ -151,9 +153,9 @@ extension RLMArray {
         }
         return index
     }
-
+    
     public typealias Index = UInt
-
+    
     public func append(_ newElement: RLMObject) {
         self.addObjectNonGeneric(newElement)
     }
@@ -203,12 +205,12 @@ public class RealmSwiftObjectAdapterBridge<T>: Adapter {
     }
     
     public func save(objects: [BaseType]) throws {
-        let rlmObjs = objects.map { unsafeBitCast($0, to: type(of: self.realmObjCAdapter).BaseType.self) }
+        let rlmObjs = objects.map { unsafeDowncast($0 as AnyObject, to: type(of: self.realmObjCAdapter).BaseType.self) }
         try self.realmObjCAdapter.save(objects: rlmObjs)
     }
     
     public func deleteObject(_ obj: BaseType) throws {
-        let rlmObj = unsafeBitCast(obj, to: type(of: self.realmObjCAdapter).BaseType.self)
+        let rlmObj = unsafeDowncast(obj as AnyObject, to: type(of: self.realmObjCAdapter).BaseType.self)
         try self.realmObjCAdapter.deleteObject(rlmObj)
     }
     

--- a/RealmCrustTests/RealmMappings.swift
+++ b/RealmCrustTests/RealmMappings.swift
@@ -272,13 +272,13 @@ public extension Binding where M: RealmMapping, M.MappedObject: RLMObject {
 }
 
 @discardableResult
-public func <- <T: RLMObject, U: RealmMapping, C: MappingContext>(field: RLMArray<T>, binding:(key: Binding<U>, context: C)) -> C where U.MappedObject == T, T: Equatable {
+public func <- <U: RealmMapping, C: MappingContext>(field: RLMArray<U.MappedObject>, binding:(key: Binding<U>, context: C)) -> C {
     
     return map(toRLMArray: field, using: binding)
 }
 
 @discardableResult
-public func map<T: RLMObject, U: RealmMapping, C: MappingContext>(toRLMArray field: RLMArray<T>, using binding:(key: Binding<U>, context: C)) -> C where U.MappedObject == T, T: Equatable {
+public func map<U: RealmMapping, C: MappingContext>(toRLMArray field: RLMArray<U.MappedObject>, using binding:(key: Binding<U>, context: C)) -> C {
     
     var variableList = RLMArrayBridge(rlmArray: field)
     let bridge = binding.key.generateRLMArrayMappingBridge()

--- a/RealmCrustTests/Tests.swift
+++ b/RealmCrustTests/Tests.swift
@@ -35,8 +35,8 @@ public class UserMapping: RealmMapping {
         let birthdateMapping = DateMapping(dateFormatter: DateFormatter.isoFormatter)
         let primaryKeyMapping = PrimaryKeyMapping()
         
-        toMap.birthDate     <- (Binding.mapping("birthdate", birthdateMapping), context)
-        toMap.identifier    <- (Binding.mapping("id_hash", primaryKeyMapping), context)
+        toMap.birthDate     <- (.mapping("birthdate", birthdateMapping), context)
+        toMap.identifier    <- (.mapping("id_hash", primaryKeyMapping), context)
         toMap.name          <- ("user_name", context)
         toMap.surname       <- ("user_surname", context)
         toMap.height        <- ("height", context)


### PR DESCRIPTION
* Adjusted code to better play with the Swift 3.1 compiler (less "ambiguous reference of" bs).
* Crust now supports mapping non-equatable collections.