### PR TITLE
Nullable collections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: objective-c
 osx_image: xcode8.3
 xcode_workspace: Crust.xcworkspace
 xcode_scheme: Crust
-xcode_sdk: iphonesimulator10.1
+xcode_sdk: iphonesimulator10.3
 script:
  - set -o pipefail
  - xcodebuild -version
  - xcodebuild -showsdks
- - xcodebuild -workspace Crust.xcworkspace -scheme Crust -sdk iphonesimulator -destination "OS=10.1,name=iPhone 7" ONLY_ACTIVE_ARCH=NO build test
+ - xcodebuild -workspace Crust.xcworkspace -scheme Crust -sdk iphonesimulator -destination "OS=10.3,name=iPhone 7" ONLY_ACTIVE_ARCH=NO build test

--- a/Crust.xcodeproj/project.pbxproj
+++ b/Crust.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		3C1EAD7F3E1C53F7D78345FD /* Pods_Crust.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28F442A36FBC57DF1CD33439 /* Pods_Crust.framework */; };
 		97101AED7BD14AF79D49A8FA /* Pods_Crust_CrustTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9343FCC42E1A2DE8316C0D87 /* Pods_Crust_CrustTests.framework */; };
 		CD2014201E30135100D16F14 /* CollectionMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD20141F1E30135100D16F14 /* CollectionMappingTests.swift */; };
+		CD57E9561EAEB39800FB4C80 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57E9551EAEB39800FB4C80 /* Utilities.swift */; };
+		CD57E9581EAEB7F300FB4C80 /* CollectionMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57E9571EAEB7F300FB4C80 /* CollectionMappingTests.swift */; };
 		CDFA6C8F1E4BE45D00E30982 /* RLMArrayBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFA6C8E1E4BE45D00E30982 /* RLMArrayBridge.swift */; };
 /* End PBXBuildFile section */
 
@@ -114,6 +116,8 @@
 		9343FCC42E1A2DE8316C0D87 /* Pods_Crust_CrustTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Crust_CrustTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B69217840C166BBAD301629D /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD20141F1E30135100D16F14 /* CollectionMappingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionMappingTests.swift; sourceTree = "<group>"; };
+		CD57E9551EAEB39800FB4C80 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		CD57E9571EAEB7F300FB4C80 /* CollectionMappingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionMappingTests.swift; sourceTree = "<group>"; };
 		CDFA6C8E1E4BE45D00E30982 /* RLMArrayBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RLMArrayBridge.swift; sourceTree = "<group>"; };
 		CE09890A415010E6701B39AE /* Pods-Crust-CrustTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Crust-CrustTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Crust-CrustTests/Pods-Crust-CrustTests.release.xcconfig"; sourceTree = "<group>"; };
 		DED40EDD9475BB525B3AEE0E /* Pods_Crust_RealmCrustTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Crust_RealmCrustTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -152,6 +156,7 @@
 			isa = PBXGroup;
 			children = (
 				172FBC8F1C15279C00CF2C71 /* AnyAdapter.swift */,
+				CD57E9551EAEB39800FB4C80 /* Utilities.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -238,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				26951C381AFB401B007B0E07 /* Supporting Files */,
+				CD57E9571EAEB7F300FB4C80 /* CollectionMappingTests.swift */,
 				17B583541C24B965005DBFA6 /* Company.swift */,
 				17B983D31BDC8D7E006BD35C /* CompanyMappingTests.swift */,
 				17B983D51BDC8DB1006BD35C /* CompanyStub.swift */,
@@ -563,6 +569,7 @@
 				175C9A431C311DB200B0D6E7 /* Mapper.swift in Sources */,
 				175C9A441C311DB200B0D6E7 /* MappingOperator.swift in Sources */,
 				175C9A451C311DB200B0D6E7 /* MappingProtocols.swift in Sources */,
+				CD57E9561EAEB39800FB4C80 /* Utilities.swift in Sources */,
 				175C9A471C311DB200B0D6E7 /* AnyAdapter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -602,6 +609,7 @@
 				17B983CE1BDC8B6A006BD35C /* EmployeeStub.swift in Sources */,
 				172FBC8C1C15140300CF2C71 /* Person.swift in Sources */,
 				17B583571C24B965005DBFA6 /* Employee.swift in Sources */,
+				CD57E9581EAEB7F300FB4C80 /* CollectionMappingTests.swift in Sources */,
 				17B983D01BDC8B95006BD35C /* Operators.swift in Sources */,
 				17B983D41BDC8D7E006BD35C /* CompanyMappingTests.swift in Sources */,
 				17B583561C24B965005DBFA6 /* Company.swift in Sources */,

--- a/Crust/Mapper/Mapper.swift
+++ b/Crust/Mapper/Mapper.swift
@@ -45,6 +45,19 @@ public struct Mapper {
         return collection
     }
     
+    public func map<M: Mapping, C: RangeReplaceableCollection>(from json: JSONValue, using binding: Binding<M>) throws -> C
+        where M.MappedObject == C.Iterator.Element {
+            
+            var collection = C()
+            let context = MappingContext(withObject: collection, json: json, direction: MappingDirection.fromJSON)
+            
+            try binding.mapping.start(context: context)
+            collection <- (binding, context)
+            try binding.mapping.completeMapping(collection: collection, context: context)
+            
+            return collection
+    }
+    
     public func map<M: Mapping>(from json: JSONValue, using binding: Binding<M>, parentContext: MappingContext? = nil) throws -> M.MappedObject {
         
         // TODO: Figure out better ways to represent `nil` keyPaths than `""`.

--- a/Crust/Mapper/MappingOperator.swift
+++ b/Crust/Mapper/MappingOperator.swift
@@ -226,14 +226,7 @@ private func map<T, M: Mapping>(to json: JSONValue, from field: T?, via key: Key
 // MARK: - From JSON
 
 private func map<T: JSONable>(from json: JSONValue, to field: inout T) throws where T.ConversionType == T {
-    
-    if let fromJson = T.fromJSON(json) {
-        field = fromJson
-    }
-    else {
-        let userInfo = [ NSLocalizedFailureReasonErrorKey : "Conversion of JSON \(json.values()) to type \(T.self) failed" ]
-        throw NSError(domain: CrustMappingDomain, code: -1, userInfo: userInfo)
-    }
+    field = try map(from: json)
 }
 
 private func map<T: JSONable>(from json: JSONValue, to field: inout T?) throws where T.ConversionType == T {
@@ -243,8 +236,12 @@ private func map<T: JSONable>(from json: JSONValue, to field: inout T?) throws w
         return
     }
     
+    field = try map(from: json)
+}
+
+private func map<T: JSONable>(from json: JSONValue) throws -> T where T.ConversionType == T {
     if let fromJson = T.fromJSON(json) {
-        field = fromJson
+        return fromJson
     }
     else {
         let userInfo = [ NSLocalizedFailureReasonErrorKey : "Conversion of JSON \(json.values()) to type \(T.self) failed" ]
@@ -269,7 +266,14 @@ private func map<T, M: Mapping>(from json: JSONValue, to field: inout T?, using 
     field = try mapper.map(from: json, using: mapping, parentContext: context)
 }
 
-// MARK: - RangeReplaceableCollectionType (Array and Realm List follow this protocol).
+// MARK: - RangeReplaceableCollection (Array and Realm List follow this protocol).
+
+/// The set of functions required to perform uniquing when inserting objects into a collection.
+public typealias UniquingFunctions<T, RRC: RangeReplaceableCollection> = (
+    elementEquality: ((T) -> (T) -> Bool),
+    indexOf: ((RRC) -> (T) -> RRC.Index?),
+    contains: ((RRC) -> (T) -> Bool)
+)
 
 /// This handles the case where our Collection contains Equatable objects, and thus can be uniqued during insertion and deletion.
 @discardableResult
@@ -282,9 +286,75 @@ public func <- <T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollecti
 @discardableResult
 public func <- <T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>(field: inout RRC, binding:(key: Binding<M>, context: MC)) -> MC where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject {
     
-    return map(toCollection: &field, using: binding, elementEquality: nil, indexOf: nil, contains: nil)
+    return map(toCollection: &field, using: binding, uniquing: nil)
 }
 
+//// Optional types.
+//
+//@discardableResult
+//public func <- <T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>(field: inout RRC?, binding:(key: Binding<M>, context: MC)) -> MC where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject, T: Equatable {
+//    
+//    return map(toCollection: &field, using: binding)
+//}
+//
+///// This is for Collections with non-Equatable objects.
+//@discardableResult
+//public func <- <M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>(field: inout RRC?, binding:(key: Binding<M>, context: MC)) -> MC where RRC.Iterator.Element == M.MappedObject {
+//    
+//    let uniquingFunctions: UniquingFunctions<M.MappedObject, RRC> = ({ _ in { _ in false }}, { _ in { _ in nil }}, { _ in { _ in false }})
+//    
+//    return map(toCollection: &field, using: binding, uniquing: uniquingFunctions)
+//}
+
+/// Map into a `RangeReplaceableCollection` with `Equatable` `Element`.
+@discardableResult
+public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>
+    (toCollection field: inout RRC,
+     using binding:(key: Binding<M>, context: MC))
+    -> MC
+    where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject, T: Equatable {
+        
+        let equality: (T) -> (T) -> Bool = { obj in
+            { compared in
+                obj == compared
+            }
+        }
+        
+        let uniquingFunctions = (equality, RRC.index(of:), RRC.contains)
+        
+        return map(toCollection: &field, using: binding, uniquing: uniquingFunctions)
+}
+
+/// General function to mapping JSON into a `RangeReplaceableCollection`.
+///
+/// Providing uniqing functions for equality comparison, fetching by index, and checking existence of elements allows
+/// for uniquing (merging/eliminating duplicates).
+@discardableResult
+public func map<M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>
+    (toCollection field: inout RRC,
+     using binding:(key: Binding<M>, context: MC),
+     uniquing: UniquingFunctions<M.MappedObject, RRC>?)
+    -> MC
+    where RRC.Iterator.Element == M.MappedObject {
+    
+    do {
+        switch binding.context.dir {
+        case .toJSON:
+            let json = binding.context.json
+            try binding.context.json = Crust.map(to: json, from: field, via: binding.key.keyPath, using: binding.key.mapping)
+            
+        case .fromJSON:
+            try mapFromJSON(toCollection: &field, using: binding, uniquing: uniquing)
+        }
+    }
+    catch let error as NSError {
+        binding.context.error = error
+    }
+    
+    return binding.context
+}
+
+/// Our top level mapping function for mapping from a sequence/collection to JSON.
 private func map<T, M: Mapping, S: Sequence>(
     to json: JSONValue,
     from field: S,
@@ -303,137 +373,147 @@ private func map<T, M: Mapping, S: Sequence>(
         return json
 }
 
-@discardableResult
-public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>
-    (toCollection field: inout RRC,
-     using binding:(key: Binding<M>, context: MC))
-    -> MC
-    where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject, T: Equatable {
-        
-        let equality: (T) -> (T) -> Bool = { obj in
-            { compared in
-                obj == compared
-            }
-        }
-        
-        return map(toCollection: &field, using: binding, elementEquality: equality, indexOf: RRC.index(of:), contains: RRC.contains)
-}
-
-@discardableResult
-public func map<T, M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>
+/// Our top level mapping function for mapping from JSON into a collection.
+private func mapFromJSON<M: Mapping, MC: MappingContext, RRC: RangeReplaceableCollection>
     (toCollection field: inout RRC,
      using binding:(key: Binding<M>, context: MC),
-     elementEquality: ((T) -> (T) -> Bool)?,
-     indexOf: ((RRC) -> (T) -> RRC.Index?)?,
-     contains: ((RRC) -> (T) -> Bool)?)
-    -> MC
-    where M.MappedObject == T, RRC.Iterator.Element == M.MappedObject {
+     uniquing: UniquingFunctions<M.MappedObject, RRC>?) throws
+    where RRC.Iterator.Element == M.MappedObject {
+        
+        let fieldCopy = field
+        let contains = uniquing?.contains(fieldCopy) ?? { _ in false }
+        let elementEquality = uniquing?.elementEquality ?? { _ in { _ in false } }
+        let optionalNewValues = try mapFromJsonToSequenceOfNewValues(
+            map: binding,
+            newValuesContains: elementEquality,
+            fieldContains: contains)
+        
+        let newValues = try transform(newValues: optionalNewValues, via: binding.key.keyPath, forUpdatePolicyNullability: binding.key.collectionUpdatePolicy)
+        
+        try insert(into: &field, newValues: newValues, using: binding.key.mapping, updatePolicy: binding.key.collectionUpdatePolicy, indexOf: uniquing?.indexOf)
+}
+
+/// Handles null JSON values. Only nullable collections do not error on null (newValues == nil).
+private func transform<T>(
+    newValues: [T]?,
+    via keyPath: Keypath,
+    forUpdatePolicyNullability updatePolicy: CollectionUpdatePolicy<T>)
+    throws -> [T] {
     
-    do {
-        switch binding.context.dir {
-        case .toJSON:
-            let json = binding.context.json
-            try binding.context.json = Crust.map(to: json, from: field, via: binding.key.keyPath, using: binding.key.mapping)
+    if let newValues = newValues {
+        return newValues
+    }
+    else if updatePolicy.nullable {
+        return []
+    }
+    else {
+        let userInfo = [ NSLocalizedFailureReasonErrorKey : "Attempting to assign \"null\" to non-nullable collection on type \(T.self) using JSON at key path \(keyPath) is not allowed. Please change the `CollectionUpdatePolicy` for this mapping to have `nullable: true`" ]
+        throw NSError(domain: CrustMappingDomain, code: 0, userInfo: userInfo)
+    }
+}
+
+/// Inserts final mapped values into the collection.
+private func insert<M: Mapping, RRC: RangeReplaceableCollection>
+    (into field: inout RRC,
+     newValues: [M.MappedObject],
+     using mapping: M,
+     updatePolicy: CollectionUpdatePolicy<M.MappedObject>,
+     indexOf: ((RRC) -> (M.MappedObject) -> RRC.Index?)?)
+    throws
+    where RRC.Iterator.Element == M.MappedObject {
+    
+        switch updatePolicy.insert {
+        case .append:
+            field.append(contentsOf: newValues)
             
-        case .fromJSON:
-            let fieldCopy = field
-            let contains = contains?(fieldCopy)
-            let (newObjects, _) = try mapFromJsonToSequence(
-                map: binding,
-                newObjectsContains: elementEquality ?? { _ in { _ in false } },
-                fieldContains: contains ?? { _ in false })
+        case .replace(delete: let deletionBlock):
+            var orphans: RRC = field
             
-            switch binding.key.collectionUpdatePolicy.insert {
-            case .append:
-                field.append(contentsOf: newObjects)
-                
-            case .replace(delete: let deletionBlock):
-                var orphans: RRC = field
-                
-                if let deletion = deletionBlock {
-                    // Check if any of our newly mapped objects previously existed in our collection
-                    // and prune them from orphans, because in which case, we don't want to delete them.
-                    if let indexOfFunc = indexOf?(orphans) {
-                        newObjects.forEach {
-                            if let index = indexOfFunc($0) {
-                                orphans.remove(at: index)
-                            }
+            if let deletion = deletionBlock {
+                // Check if any of our newly mapped objects previously existed in our collection
+                // and prune them from orphans, because in which case, we don't want to delete them.
+                if let indexOfFunc = indexOf?(orphans) {
+                    newValues.forEach {
+                        if let index = indexOfFunc($0) {
+                            orphans.remove(at: index)
                         }
-                    }
-                    
-                    // Unfortunately `AnyCollection<U.MappedObject>(orphans)` gives us "type is ambiguous without more context".
-                    let arrayOrphans = Array(orphans)
-                    let shouldDelete = AnyCollection<M.MappedObject>(arrayOrphans)
-                    try deletion(shouldDelete).forEach {
-                        try binding.key.mapping.delete(obj: $0)
                     }
                 }
                 
-                field.removeAll(keepingCapacity: true)
-                field.append(contentsOf: newObjects)
+                // Unfortunately `AnyCollection<U.MappedObject>(orphans)` gives us "type is ambiguous without more context".
+                let arrayOrphans = Array(orphans)
+                let shouldDelete = AnyCollection<M.MappedObject>(arrayOrphans)
+                try deletion(shouldDelete).forEach {
+                    try mapping.delete(obj: $0)
+                }
             }
+            
+            field.removeAll(keepingCapacity: true)
+            field.append(contentsOf: newValues)
         }
-    }
-    catch let error as NSError {
-        binding.context.error = error
-    }
-    
-    return binding.context
 }
 
-// Gets all newly mapped data and returns it in an array, caller can decide to append and what-not.
-private func mapFromJsonToSequence<T, M: Mapping, MC: MappingContext>(
+/// Gets all newly mapped data and returns it in an array.
+///
+/// - returns: The array of mapped values, `nil` if JSON at keypath is "null".
+private func mapFromJsonToSequenceOfNewValues<M: Mapping, MC: MappingContext>(
     map:(key: Binding<M>, context: MC),
-    newObjectsContains: @escaping (T) -> (T) -> Bool,
-    fieldContains: (T) -> Bool)
-    throws -> (newObjects: [T], context: MC)
-    where M.MappedObject == T {
+    newValuesContains: @escaping (M.MappedObject) -> (M.MappedObject) -> Bool,
+    fieldContains: (M.MappedObject) -> Bool)
+    throws -> [M.MappedObject]? {
     
         guard map.context.error == nil else {
             throw map.context.error!
         }
         
         let mapping = map.key.mapping
-        var newObjects: [T] = []
+        let baseJSON: JSONValue = try {
+            let json = map.context.json
+            let baseJSON = json[map.key.keyPath]
+            
+            // Walked an empty keypath, return the whole json payload if it's an empty array since subscripting on a json array calls `map`.
+            // TODO: May be simpler to support `nil` keyPaths.
+            if case .some(.array(let arr)) = baseJSON, map.key.keyPath == "", arr.count == 0 {
+                return json
+            }
+            else if let baseJSON = baseJSON {
+                return baseJSON
+            }
+            else {
+                let userInfo = [ NSLocalizedFailureReasonErrorKey : "JSON at key path \(map.key) does not exist to map from" ]
+                throw NSError(domain: CrustMappingDomain, code: 0, userInfo: userInfo)
+            }
+        }()
         
-        let json = map.context.json
-        let baseJSON = json[map.key.keyPath]
         let updatePolicy = map.key.collectionUpdatePolicy
         
-        // TODO: Stupid hack for empty string keypaths. Fix by allowing `nil` keyPath.
-        if case .some(.array(let arr)) = baseJSON, map.key.keyPath == "", arr.count == 0 {
-            newObjects = try generateNewValues(fromJsonArray: json,
-                                     with: updatePolicy,
-                                     using: mapping,
-                                     newObjectsContains: newObjectsContains,
-                                     fieldContains: fieldContains,
-                                     context: map.context)
-        }
-        else if let baseJSON = baseJSON {
-            newObjects = try generateNewValues(fromJsonArray: baseJSON,
-                                     with: updatePolicy,
-                                     using: mapping,
-                                     newObjectsContains: newObjectsContains,
-                                     fieldContains: fieldContains,
-                                     context: map.context)
-        }
-        else {
-            let userInfo = [ NSLocalizedFailureReasonErrorKey : "JSON at key path \(map.key) does not exist to map from" ]
-            throw NSError(domain: CrustMappingDomain, code: 0, userInfo: userInfo)
-        }
+        let newValues = try generateNewValues(fromJsonArray: baseJSON,
+                                              with: updatePolicy,
+                                              using: mapping,
+                                              newValuesContains: newValuesContains,
+                                              fieldContains: fieldContains,
+                                              context: map.context)
         
-        return (newObjects, map.context)
+        return newValues
 }
 
+/// Generates and returns our new set of values from the JSON that will later be inserted into the collection
+/// we're mapping into.
+///
+/// - returns: The array of mapped values, `nil` if JSON is "null".
 private func generateNewValues<T, M: Mapping>(
     fromJsonArray json: JSONValue,
     with updatePolicy: CollectionUpdatePolicy<M.MappedObject>,
     using mapping: M,
-    newObjectsContains: @escaping (T) -> (T) -> Bool,
+    newValuesContains: @escaping (T) -> (T) -> Bool,
     fieldContains: (T) -> Bool,
     context: MappingContext)
-    throws -> [T]
+    throws -> [T]?
     where M.MappedObject == T {
+        
+        if case .null() = json, updatePolicy.nullable {
+            return nil
+        }
     
         guard case .array(let jsonArray) = json else {
             let userInfo = [ NSLocalizedFailureReasonErrorKey : "Trying to map json of type \(type(of: json)) to Collection of <\(T.self)>" ]
@@ -442,31 +522,31 @@ private func generateNewValues<T, M: Mapping>(
         
         let mapper = Mapper()
         
-        var newObjects = [T]()
-        
-        let isUnique = { (obj: T, newObjects: [T], fieldContains: (T) -> Bool) -> Bool in
-            let newObjectsContainsObj = newObjects.contains(where: newObjectsContains(obj))
+        let isUnique = { (val: T, newValues: [T], fieldContains: (T) -> Bool) -> Bool in
+            let newValuesContainsVal = newValues.contains(where: newValuesContains(val))
             
             switch updatePolicy.insert {
             case .replace(_):
-                return !newObjectsContainsObj
+                return !newValuesContainsVal
             case .append:
-                return !(newObjectsContainsObj || fieldContains(obj))
+                return !(newValuesContainsVal || fieldContains(val))
             }
         }
         
+        var newValues = [T]()
+        
         for json in jsonArray {
-            let obj = try mapper.map(from: json, using: mapping, parentContext: context)
+            let val = try mapper.map(from: json, using: mapping, parentContext: context)
             
             if updatePolicy.unique {
-                if isUnique(obj, newObjects, fieldContains) {
-                    newObjects.append(obj)
+                if isUnique(val, newValues, fieldContains) {
+                    newValues.append(val)
                 }
             }
             else {
-                newObjects.append(obj)
+                newValues.append(val)
             }
         }
         
-        return newObjects
+        return newValues
 }

--- a/Crust/Mapper/MappingProtocols.swift
+++ b/Crust/Mapper/MappingProtocols.swift
@@ -7,7 +7,7 @@ public enum CollectionInsertionMethod<Element> {
 }
 
 public typealias CollectionUpdatePolicy<Element> =
-    (insert: CollectionInsertionMethod<Element>, unique: Bool)
+    (insert: CollectionInsertionMethod<Element>, unique: Bool, nullable: Bool)
 
 public enum Binding<M: Mapping> {
     
@@ -35,7 +35,7 @@ public enum Binding<M: Mapping> {
     public var collectionUpdatePolicy: CollectionUpdatePolicy<M.MappedObject> {
         switch self {
         case .mapping(_, _):
-            return (.replace(delete: nil), true)
+            return (.replace(delete: nil), true, true)
         case .collectionMapping(_, _, let method):
             return method
         }

--- a/Crust/Utilities/Utilities.swift
+++ b/Crust/Utilities/Utilities.swift
@@ -1,0 +1,11 @@
+public extension Collection where Iterator.Element: Equatable {
+    public static func defaultUniquingFunctions() -> UniquingFunctions<Iterator.Element, Self> {
+        let equality: (Iterator.Element) -> (Iterator.Element) -> Bool = { obj in
+        { compared in
+            obj == compared
+            }
+        }
+        
+        return (equality, Self.index(of:), Self.contains)
+    }
+}

--- a/CrustTests/CollectionMappingTests.swift
+++ b/CrustTests/CollectionMappingTests.swift
@@ -5,7 +5,7 @@ import JSONValueRX
 // We test the following.
 // | append / replace  | nullable  | vals / null | Array     | Array?      | RLMArray  |
 // |-------------------|-----------|-------------|-----------|-------------|-----------|
-// | append            | yes or no | append      | append    | append      | append    |
+// | append            | yes or no | vals        | append    | append      | append    |
 // | append            | yes       | null        | no-op     | no-op       | no-op     |
 // | replace           | yes or no | vals        | replace   | replace     | replace   |
 // | replace           | yes       | null        | removeAll | assign null | removeAll |

--- a/CrustTests/CollectionMappingTests.swift
+++ b/CrustTests/CollectionMappingTests.swift
@@ -1,0 +1,408 @@
+import XCTest
+import Crust
+import JSONValueRX
+
+// We test the following.
+// | append / replace  | nullable  | vals / null | Array     | Array?      | RLMArray  |
+// |-------------------|-----------|-------------|-----------|-------------|-----------|
+// | append            | yes or no | append      | append    | append      | append    |
+// | append            | yes       | null        | no-op     | no-op       | no-op     |
+// | replace           | yes or no | vals        | replace   | replace     | replace   |
+// | replace           | yes       | null        | removeAll | assign null | removeAll |
+// | append or replace | no        | null        | error     | error       | error     |
+
+extension Int: AnyMappable { }
+
+class CollectionMappingTests: XCTestCase {
+    
+    class IntMapping: AnyMapping {
+        typealias AdapterKind = AnyAdapterImp<Int>
+        typealias MappedObject = Int
+        func mapping(toMap: inout Int, context: MappingContext) { }
+    }
+    
+    func testDefaultInsertionPolicyIsReplaceUniqueNullable() {
+        let binding = Binding.mapping("", IntMapping())
+        let policy = binding.collectionUpdatePolicy
+        guard case (.replace(delete: nil), true, true) = policy else {
+            XCTFail()
+            return
+        }
+    }
+    
+    func testMappingCollection() {
+        let employeeStub = EmployeeStub()
+        let employeeStub2 = EmployeeStub()
+        let json = try! JSONValue(object: employeeStub.generateJsonObject())
+        let json2 = try! JSONValue(object: employeeStub2.generateJsonObject())
+        let employeesJSON = JSONValue.array([json, json2])
+        
+        let mapping = EmployeeMapping(adapter: MockAdapter<Employee>())
+        let mapper = Mapper()
+        
+        let spec = Binding.mapping("", mapping)
+        let collection: [Employee] = try! mapper.map(from: employeesJSON, using: spec)
+        
+        XCTAssertEqual(collection.count, 2)
+        XCTAssertNotEqual(collection[0].uuid, collection[1].uuid)
+        XCTAssertTrue(employeeStub.matches(collection[0]))
+        XCTAssertTrue(employeeStub2.matches(collection[1]))
+    }
+    
+    // | append / replace  | nullable  | vals / null | Array     |
+    // |-------------------|-----------|-------------|-----------|
+    // | append            | yes or no | append      | append    |
+    func testMappingCollectionByAppend() {
+        class CompanyMappingAppendUnique: CompanyMapping {
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
+                toMap.employees <- (Binding.collectionMapping("employees", employeeMapping, (.append, true, false)), context)
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        
+        let original = Company()
+        let employee1 = Employee()   // 1.
+        let employee2 = Employee()        // 2.
+        original.uuid = uuid
+        employee1.uuid = uuid
+        employee2.uuid = NSUUID().uuidString
+        original.employees.append(employee1)
+        original.employees.append(employee2)
+        
+        let companyStub = CompanyStub()
+        let employeeStub3 = EmployeeStub()   // 3.
+        let employeeStub4 = EmployeeStub()  // 4.
+        companyStub.uuid = uuid
+        companyStub.employees = [employeeStub3, employeeStub4]
+        let json = try! JSONValue(object: companyStub.generateJsonObject())
+        
+        let mapping = CompanyMappingAppendUnique(adapter: MockAdapter<Company>())
+        let mapper = Mapper()
+        
+        let company: Company = try! mapper.map(from: json, to: original, using: mapping)
+        let employees = company.employees
+        
+        XCTAssertEqual(original.uuid, company.uuid)
+        XCTAssertEqual(employees.count, 4)
+        XCTAssertEqual(employees[0].uuid, employee1.uuid)
+        XCTAssertTrue(employeeStub3.matches(employees[2]))
+        XCTAssertTrue(employeeStub4.matches(employees[3]))
+    }
+    
+    // | append / replace  | nullable  | vals / null | Array     |
+    // |-------------------|-----------|-------------|-----------|
+    // | replace           | yes or no | vals        | replace   |
+    func testMappingCollectionByReplace() {
+        class CompanyMappingReplaceUnique: CompanyMapping {
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
+                toMap.employees <- (.collectionMapping("employees", employeeMapping, (.replace(delete: nil), true, false)), context)
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        
+        let original = Company()
+        let originalEmployee = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        original.employees.append(originalEmployee)
+        
+        let companyStub = CompanyStub()
+        let employeeStub = EmployeeStub()
+        let employeeStub2 = EmployeeStub()
+        companyStub.uuid = original.uuid
+        companyStub.employees = [employeeStub, employeeStub2]
+        let json = try! JSONValue(object: companyStub.generateJsonObject())
+        
+        let mapping = CompanyMappingReplaceUnique(adapter: MockAdapter<Company>())
+        let mapper = Mapper()
+        
+        let company: Company = try! mapper.map(from: json, to: original, using: mapping)
+        let employees = company.employees
+        
+        XCTAssertEqual(original.uuid, company.uuid)
+        XCTAssertEqual(employees.count, 2)
+        XCTAssertTrue(employeeStub.matches(employees[0]))
+        XCTAssertTrue(employeeStub2.matches(employees[1]))
+    }
+    
+    // | append / replace  | nullable  | vals / null | Array     |
+    // |-------------------|-----------|-------------|-----------|
+    // | replace           | yes or no | vals        | replace   |
+    func testMappingCollectionByReplaceDelete() {
+        class CompanyMappingReplaceDeleteUnique: CompanyMapping {
+            let employeeAdapter = MockAdapter<Employee>()
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: employeeAdapter)
+                toMap.employees <- (.collectionMapping("employees", employeeMapping, (.replace(delete: { $0 }), true, false)), context)
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let originalEmployee2Stub = EmployeeStub()
+        
+        let original = Company()
+        let originalEmployee = Employee()
+        let originalEmployee2 = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        originalEmployee2.uuid = originalEmployee2Stub.uuid
+        original.employees.append(originalEmployee)
+        original.employees.append(originalEmployee2)
+        
+        let companyStub = CompanyStub()
+        let employeeStub = EmployeeStub()
+        let employeeStub2 = EmployeeStub()
+        companyStub.employees = [employeeStub, employeeStub2, employeeStub, originalEmployee2Stub]
+        companyStub.uuid = original.uuid
+        let json = try! JSONValue(object: companyStub.generateJsonObject())
+        
+        let mapping = CompanyMappingReplaceDeleteUnique(adapter: MockAdapter<Company>())
+        let mapper = Mapper()
+        
+        let company: Company = try! mapper.map(from: json, to: original, using: mapping)
+        let employees = company.employees
+        
+        XCTAssertEqual(original.uuid, company.uuid)
+        XCTAssertEqual(mapping.employeeAdapter.deletedObjects.map { $0.uuid }, [originalEmployee.uuid, originalEmployee2.uuid])
+        XCTAssertEqual(employees.count, 4)
+        XCTAssertTrue(employeeStub.matches(employees[0]))
+        XCTAssertTrue(employeeStub2.matches(employees[1]))
+        XCTAssertTrue(employeeStub.matches(employees[2]))
+        XCTAssertTrue(originalEmployee2Stub.matches(employees[3]))
+    }
+    
+    // | append / replace  | nullable  | vals / null | Array     |
+    // |-------------------|-----------|-------------|-----------|
+    // | replace           | yes       | null        | removeAll |
+    func testAssigningNullToCollectionWhenReplaceNullableRemovesAllAndDeletes() {
+        class CompanyMappingReplaceNullable: CompanyMapping {
+            let employeeAdapter = MockAdapter<Employee>()
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: employeeAdapter)
+                toMap.employees <- (.collectionMapping("employees", employeeMapping, (.replace(delete: { $0 }), true, true)), context)
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let originalEmployee2Stub = EmployeeStub()
+        
+        let original = Company()
+        let originalEmployee = Employee()
+        let originalEmployee2 = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        originalEmployee2.uuid = originalEmployee2Stub.uuid
+        original.employees.append(originalEmployee)
+        original.employees.append(originalEmployee2)
+        
+        let companyStub = CompanyStub()
+        companyStub.employees = []
+        companyStub.uuid = original.uuid
+        var jsonObj = companyStub.generateJsonObject()
+        XCTAssertEqual(jsonObj["employees"] as! NSArray, [])    // Sanity check.
+        
+        jsonObj["employees"] = NSNull()
+        XCTAssertEqual(jsonObj["employees"] as! NSNull, NSNull())    // Sanity check.
+        
+        let json = try! JSONValue(object: jsonObj)
+        
+        let mapping = CompanyMappingReplaceNullable(adapter: MockAdapter<Company>())
+        let mapper = Mapper()
+        
+        let company: Company = try! mapper.map(from: json, to: original, using: mapping)
+        let employees = company.employees
+        
+        XCTAssertEqual(mapping.employeeAdapter.deletedObjects.map { $0.uuid }, [originalEmployee.uuid, originalEmployee2.uuid])
+        XCTAssertEqual(original.uuid, company.uuid)
+        XCTAssertEqual(employees.count, 0)
+    }
+    
+    // | append / replace  | nullable  | vals / null | Array     |
+    // |-------------------|-----------|-------------|-----------|
+    // | append            | yes       | null        | no-op     |
+    func testAssigningNullToCollectionWhenAppendNullableDoesNothing() {
+        class CompanyMappingAppendNullable: CompanyMapping {
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
+                toMap.employees <- (.collectionMapping("employees", employeeMapping, (.append, true, true)), context)
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let originalEmployee2Stub = EmployeeStub()
+        
+        let original = Company()
+        let originalEmployee = Employee()
+        let originalEmployee2 = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        originalEmployee2.uuid = originalEmployee2Stub.uuid
+        original.employees.append(originalEmployee)
+        original.employees.append(originalEmployee2)
+        
+        let companyStub = CompanyStub()
+        companyStub.employees = []
+        companyStub.uuid = original.uuid
+        var jsonObj = companyStub.generateJsonObject()
+        XCTAssertEqual(jsonObj["employees"] as! NSArray, [])    // Sanity check.
+        
+        jsonObj["employees"] = NSNull()
+        XCTAssertEqual(jsonObj["employees"] as! NSNull, NSNull())    // Sanity check.
+        
+        let json = try! JSONValue(object: jsonObj)
+        
+        let mapping = CompanyMappingAppendNullable(adapter: MockAdapter<Company>())
+        let mapper = Mapper()
+        
+        let company: Company = try! mapper.map(from: json, to: original, using: mapping)
+        let employees = company.employees
+        
+        XCTAssertEqual(employees.count, 2)
+        XCTAssertEqual(original.uuid, company.uuid)
+    }
+    
+    // | append / replace  | nullable  | vals / null | Array     |
+    // |-------------------|-----------|-------------|-----------|
+    // | append or replace | no        | null        | error     |
+    func testAssigningNullToCollectionWhenNonNullableThrows() {
+        class CompanyMappingAppendNonNullable: CompanyMapping {
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
+                toMap.employees <- (.collectionMapping("employees", employeeMapping, (.append, true, false)), context)
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let originalEmployee2Stub = EmployeeStub()
+        
+        let original = Company()
+        let originalEmployee = Employee()
+        let originalEmployee2 = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        originalEmployee2.uuid = originalEmployee2Stub.uuid
+        original.employees.append(originalEmployee)
+        original.employees.append(originalEmployee2)
+        
+        let companyStub = CompanyStub()
+        companyStub.employees = []
+        companyStub.uuid = original.uuid
+        var jsonObj = companyStub.generateJsonObject()
+        XCTAssertEqual(jsonObj["employees"] as! NSArray, [])    // Sanity check.
+        
+        jsonObj["employees"] = NSNull()
+        XCTAssertEqual(jsonObj["employees"] as! NSNull, NSNull())    // Sanity check.
+        
+        let json = try! JSONValue(object: jsonObj)
+        
+        let mapping = CompanyMappingAppendNonNullable(adapter: MockAdapter<Company>())
+        let mapper = Mapper()
+        
+        let spec = Binding.mapping("", mapping)
+        let testFunc = {
+            let _: Company = try mapper.map(from: json, using: spec)
+        }
+        
+        XCTAssertThrowsError(try testFunc())
+    }
+    
+    // MARK: - Optional Array.
+    
+    // | append / replace  | nullable  | vals / null | Array?      |
+    // |-------------------|-----------|-------------|-------------|
+    // | replace           | yes       | null        | assign null |
+    func testAssigningNullToOptionalCollectionWhenReplaceNullableAssignsNullAndDeletes() {
+        class CompanyMappingReplaceNullable: CompanyWithOptionalEmployeesMapping {
+            let employeeAdapter = MockAdapter<Employee>()
+            override func mapping(toMap: inout CompanyWithOptionalEmployees, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: employeeAdapter)
+                toMap.employees <- (.collectionMapping("employees", employeeMapping, (.replace(delete: { $0 }), true, true)), context)
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let originalEmployee2Stub = EmployeeStub()
+        
+        let original = CompanyWithOptionalEmployees()
+        original.employees = []
+        let originalEmployee = Employee()
+        let originalEmployee2 = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        originalEmployee2.uuid = originalEmployee2Stub.uuid
+        original.employees?.append(originalEmployee)
+        original.employees?.append(originalEmployee2)
+        
+        let companyStub = CompanyStub()
+        companyStub.employees = []
+        companyStub.uuid = original.uuid
+        var jsonObj = companyStub.generateJsonObject()
+        XCTAssertEqual(jsonObj["employees"] as! NSArray, [])    // Sanity check.
+        
+        jsonObj["employees"] = NSNull()
+        XCTAssertEqual(jsonObj["employees"] as! NSNull, NSNull())    // Sanity check.
+        
+        let json = try! JSONValue(object: jsonObj)
+        
+        let mapping = CompanyMappingReplaceNullable(adapter: MockAdapter<CompanyWithOptionalEmployees>())
+        let mapper = Mapper()
+        
+        let company: CompanyWithOptionalEmployees = try! mapper.map(from: json, to: original, using: mapping)
+        let employees = company.employees
+        
+        XCTAssertEqual(mapping.employeeAdapter.deletedObjects.map { $0.uuid }, [originalEmployee.uuid, originalEmployee2.uuid])
+        XCTAssertEqual(original.uuid, company.uuid)
+        XCTAssertNil(employees)
+    }
+    
+    // | append / replace  | nullable  | vals / null | Array?      |
+    // |-------------------|-----------|-------------|-------------|
+    // | append or replace | no        | null        | error       |
+    func testAssigningNullToOptionalCollectionWhenNonNullableThrows() {
+        class CompanyMappingAppendNonNullable: CompanyWithOptionalEmployeesMapping {
+            override func mapping(toMap: inout CompanyWithOptionalEmployees, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
+                toMap.employees <- (.collectionMapping("employees", employeeMapping, (.append, true, false)), context)
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let originalEmployee2Stub = EmployeeStub()
+        
+        let original = CompanyWithOptionalEmployees()
+        let originalEmployee = Employee()
+        let originalEmployee2 = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        originalEmployee2.uuid = originalEmployee2Stub.uuid
+        original.employees = []
+        original.employees?.append(originalEmployee)
+        original.employees?.append(originalEmployee2)
+        
+        let companyStub = CompanyStub()
+        companyStub.employees = []
+        companyStub.uuid = original.uuid
+        var jsonObj = companyStub.generateJsonObject()
+        XCTAssertEqual(jsonObj["employees"] as! NSArray, [])    // Sanity check.
+        
+        jsonObj["employees"] = NSNull()
+        XCTAssertEqual(jsonObj["employees"] as! NSNull, NSNull())    // Sanity check.
+        
+        let json = try! JSONValue(object: jsonObj)
+        
+        let mapping = CompanyMappingAppendNonNullable(adapter: MockAdapter<CompanyWithOptionalEmployees>())
+        let mapper = Mapper()
+        
+        let spec = Binding.mapping("", mapping)
+        let testFunc = {
+            let _: CompanyWithOptionalEmployees = try mapper.map(from: json, using: spec)
+        }
+        
+        XCTAssertThrowsError(try testFunc())
+        XCTAssertEqual(original.employees!.map { $0.uuid }, [originalEmployee.uuid, originalEmployee2.uuid])
+    }
+}

--- a/CrustTests/Company.swift
+++ b/CrustTests/Company.swift
@@ -43,7 +43,7 @@ class CompanyMappingWithDupes: CompanyMapping {
     override func mapping(toMap: inout Company, context: MappingContext) {
         let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
         
-        toMap.employees             <- .collectionMapping("employees", employeeMapping, (.append, true)) >*<
+        toMap.employees             <- .collectionMapping("employees", employeeMapping, (.append, true, true)) >*<
         toMap.founder               <- .mapping("founder", employeeMapping) >*<
         toMap.uuid                  <- "data.uuid" >*<
         toMap.name                  <- "name" >*<

--- a/CrustTests/Company.swift
+++ b/CrustTests/Company.swift
@@ -52,3 +52,41 @@ class CompanyMappingWithDupes: CompanyMapping {
         context
     }
 }
+
+class CompanyWithOptionalEmployees {
+    
+    required init() { }
+    
+    var employees: [Employee]? = nil
+    var uuid: String = ""
+    var name: String = ""
+    var foundingDate: Date = Date()
+    var founder: Employee?
+    var pendingLawsuits: Int = 0
+}
+
+extension CompanyWithOptionalEmployees: AnyMappable { }
+
+class CompanyWithOptionalEmployeesMapping: Mapping {
+    
+    var adapter: MockAdapter<CompanyWithOptionalEmployees>
+    var primaryKeys: [Mapping.PrimaryKeyDescriptor]? {
+        return [ ("uuid", "data.uuid", nil) ]
+    }
+    
+    required init(adapter: MockAdapter<CompanyWithOptionalEmployees>) {
+        self.adapter = adapter
+    }
+    
+    func mapping(toMap: inout CompanyWithOptionalEmployees, context: MappingContext) {
+        let employeeMapping = EmployeeMapping(adapter: MockAdapter<Employee>())
+        
+        toMap.employees         <- .mapping("employees", employeeMapping) >*<
+        toMap.founder           <- .mapping("founder", employeeMapping) >*<
+        toMap.uuid              <- "data.uuid" >*<
+        toMap.name              <- "name" >*<
+        toMap.foundingDate      <- "data.founding_date"  >*<
+        toMap.pendingLawsuits   <- "data.lawsuits.pending"  >*<
+        context
+    }
+}

--- a/CrustTests/Mocks.swift
+++ b/CrustTests/Mocks.swift
@@ -1,6 +1,8 @@
 import Crust
 
 class MockAdapter<T: AnyMappable>: Adapter {
+    var deletedObjects = [T]()
+    
     typealias BaseType = T
     typealias ResultsType = [T]
     
@@ -10,7 +12,7 @@ class MockAdapter<T: AnyMappable>: Adapter {
     public func sanitize(primaryKeyProperty property: String, forValue value: CVarArg, ofType type: T.Type) -> CVarArg? { return nil }
     func fetchObjects(type: BaseType.Type, primaryKeyValues: [[String : CVarArg]], isMapping: Bool) -> ResultsType? { return [] }
     func createObject(type: BaseType.Type) throws -> BaseType { return type.init() }
-    func deleteObject(_ obj: BaseType) throws { }
+    func deleteObject(_ obj: BaseType) throws { deletedObjects.append(obj) }
     func save(objects: [ BaseType ]) throws { }
 }
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A flexible Swift framework for converting classes and structs to and from JSON w
 - [Type safe JSON](#jsonvalue-for-type-safe-json)
 - [How To Map](#how-to-map)
   - [Nested Mappings](#nested-mappings)
+  - [Binding and Collections](#binding-and-collections)
   - [Mapping Context](#mapping-context)
   - [Custom Transformations](#custom-transformations)
   - [Different Mappings for Same Model](#different-mappings-for-same-model)
@@ -173,9 +174,9 @@ func mapping(inout toMap: Company, context: MappingContext) {
 * replace and/or delete objects
 * append objects to the collection
 * unique objects in collection (merge duplicates)
-  * Latest object overwrites existing object on merge.
-  * Uniquing only works if the `Element` of the collection being mapped to follows `Equatable`.
-  * If the `Element` does not follow `Equatable` it is also possible to use `map(toCollection field:, using binding:, elementEquality:, indexOf:, contains:)` to provide explicit comparison / indexing functions required for uniquing.
+  * The latest mapped properties overwrite the existing object's properties during uniquing. Properties not mapped remain unchanged.
+  * Uniquing works automatically if the `Element`s of the collection being mapped follow `Equatable`.
+  * If the `Element`s do not follow `Equatable` then uniquing is ignored unless `UniquingFunctions` are explicitly provided and the mapping function `map(toCollection field:, using binding:, uniquing:)` is used.
 * Accept "null" values to map from the collection.
 
 This table provides some examples of how "null" json values are mapped depending on the type of Collection being mapped to and given the value of `nullable` and whether values or "null" are present in the JSON payload.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ This table provides some examples of how "null" json values are mapped depending
 
 | append / replace  | nullable  | vals / null | Array     | Array?      | RLMArray  |
 |-------------------|-----------|-------------|-----------|-------------|-----------|
-| append            | yes or no | append      | append    | append      | append    |
+| append            | yes or no | vals        | append    | append      | append    |
 | append            | yes       | null        | no-op     | no-op       | no-op     |
 | replace           | yes or no | vals        | replace   | replace     | replace   |
 | replace           | yes       | null        | removeAll | assign null | removeAll |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ func mapping(inout toMap: Company, context: MappingContext) {
 }
 ```
 
-### Binding and collections
+### Binding and Collections
 
 `Binding` provides specialized directives when mapping collections. Use the `.collectionMapping` case to inform the mapper of these directives. They include
 * replace and/or delete objects

--- a/README.md
+++ b/README.md
@@ -175,8 +175,19 @@ func mapping(inout toMap: Company, context: MappingContext) {
 * unique objects in collection (remove duplicates)
   * uniquing on works if the `Element` of the collection being mapped to follows `Equatable`.
   * If the `Element` does not follow `Equatable` its is also possible to use `map(toCollection field:, using binding:, elementEquality:, indexOf:, contains:)` to provide explicit comparison / indexing functions required for uniquing.
+* Accept "null" values to map from the collection.
 
-By default using `.mapping` will `(insert: .append, unique: true)`.
+This table provides some examples of how "null" json values are mapped depending on the type of Collection being mapped to and given the value of `nullable` and whether values or "null" are present in the JSON payload.
+
+| append / replace  | nullable  | vals / null | Array     | Array?      | RLMArray  |
+|-------------------|-----------|-------------|-----------|-------------|-----------|
+| append            | yes or no | append      | append    | append      | append    |
+| append            | yes       | null        | no-op     | no-op       | no-op     |
+| replace           | yes or no | vals        | replace   | replace     | replace   |
+| replace           | yes       | null        | removeAll | assign null | removeAll |
+| append or replace | no        | null        | error     | error       | error     |
+
+By default using `.mapping` will `(insert: .append, unique: true, nullable: true)`.
 
 ```swift
 public enum CollectionInsertionMethod<Container: Sequence> {
@@ -185,7 +196,7 @@ public enum CollectionInsertionMethod<Container: Sequence> {
 }
 
 public typealias CollectionUpdatePolicy<Container: Sequence> =
-    (insert: CollectionInsertionMethod<Container>, unique: Bool)
+    (insert: CollectionInsertionMethod<Container>, unique: Bool, nullable: Bool)
 
 public enum Binding<M: Mapping>: Keypath {
     case mapping(Keypath, M)
@@ -196,7 +207,7 @@ public enum Binding<M: Mapping>: Keypath {
 Usage:
 ```swift
 let employeeMapping = EmployeeMapping(adapter: CoreDataAdapter())
-let binding = Binding.collectionMapping("", employeeMapping, (.replace(delete: nil), true))
+let binding = Binding.collectionMapping("", employeeMapping, (.replace(delete: nil), true, true))
 toMap.employees <- (binding, context)
 ```
 Look in ./Mapper/MappingProtocols.swift for more.

--- a/RealmCrustTests/CollectionMappingTests.swift
+++ b/RealmCrustTests/CollectionMappingTests.swift
@@ -6,21 +6,6 @@ extension Int: AnyMappable { }
 
 class CollectionMappingTests: RealmMappingTest {
     
-    class IntMapping: AnyMapping {
-        typealias AdapterKind = AnyAdapterImp<Int>
-        typealias MappedObject = Int
-        func mapping(toMap: inout Int, context: MappingContext) { }
-    }
-    
-    func testDefaultInsertionPolicyIsReplaceUniqueNullable() {
-        let binding = Binding.mapping("", IntMapping())
-        let policy = binding.collectionUpdatePolicy
-        guard case (.replace(delete: nil), true, true) = policy else {
-            XCTFail()
-            return
-        }
-    }
-    
     func testMappingCollection() {
         let employeeStub = EmployeeStub()
         let employeeStub2 = EmployeeStub()

--- a/RealmCrustTests/CollectionMappingTests.swift
+++ b/RealmCrustTests/CollectionMappingTests.swift
@@ -12,10 +12,10 @@ class CollectionMappingTests: RealmMappingTest {
         func mapping(toMap: inout Int, context: MappingContext) { }
     }
     
-    func testDefaultInsertionPolicyIsReplaceUnique() {
+    func testDefaultInsertionPolicyIsReplaceUniqueNullable() {
         let binding = Binding.mapping("", IntMapping())
         let policy = binding.collectionUpdatePolicy
-        guard case (.replace(delete: nil), true) = policy else {
+        guard case (.replace(delete: nil), true, true) = policy else {
             XCTFail()
             return
         }
@@ -47,7 +47,7 @@ class CollectionMappingTests: RealmMappingTest {
         class CompanyMappingAppendUnique: CompanyMapping {
             override func mapping(toMap: inout Company, context: MappingContext) {
                 let employeeMapping = EmployeeMapping(adapter: self.adapter)
-                map(toRLMArray: toMap.employees, using: (Binding.collectionMapping("employees", employeeMapping, (.append, true)), context))
+                map(toRLMArray: toMap.employees, using: (Binding.collectionMapping("employees", employeeMapping, (.append, true, false)), context))
             }
         }
         
@@ -94,7 +94,7 @@ class CollectionMappingTests: RealmMappingTest {
             override func mapping(toMap: inout Company, context: MappingContext) {
                 let employeeMapping = EmployeeMapping(adapter: self.adapter)
                 map(toRLMArray: toMap.employees,
-                    using: (.collectionMapping("employees", employeeMapping, (.replace(delete: nil), true)), context))
+                    using: (.collectionMapping("employees", employeeMapping, (.replace(delete: nil), true, false)), context))
             }
         }
         
@@ -135,7 +135,7 @@ class CollectionMappingTests: RealmMappingTest {
             override func mapping(toMap: inout Company, context: MappingContext) {
                 let employeeMapping = EmployeeMapping(adapter: self.adapter)
                 map(toRLMArray: toMap.employees,
-                    using: (.collectionMapping("employees", employeeMapping, (.replace(delete: { $0 }), true)), context))
+                    using: (.collectionMapping("employees", employeeMapping, (.replace(delete: { $0 }), true, false)), context))
             }
         }
         
@@ -172,9 +172,156 @@ class CollectionMappingTests: RealmMappingTest {
         XCTAssertEqual(original.uuid, company.uuid)
         XCTAssertEqual(Employee.allObjects(in: realm!).count, 3)
         XCTAssertEqual(employees.count, 3)
-        print(employees)
         XCTAssertTrue(employeeStub.matches(object: employees[0]))
         XCTAssertTrue(employeeStub2.matches(object: employees[1]))
         XCTAssertTrue(dupEmployeeStub.matches(object: employees[2]))
+    }
+    
+    func testAssigningNullToCollectionWhenReplaceNullableRemovesAllAndDeletes() {
+        class CompanyMappingReplaceNullable: CompanyMapping {
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: self.adapter)
+                map(toRLMArray: toMap.employees,
+                    using: (.collectionMapping("employees", employeeMapping, (.replace(delete: { $0 }), true, true)), context))
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let dupEmployeeStub = EmployeeStub()
+        
+        let original = Company()
+        let originalEmployee = Employee()
+        let dupEmployee = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        dupEmployee.uuid = dupEmployeeStub.uuid
+        original.employees.append(originalEmployee)
+        original.employees.append(dupEmployee)
+        
+        let outsideEmployee = Employee()
+        
+        try! self.adapter!.save(objects: [ original, outsideEmployee ])
+        XCTAssertEqual(Company.allObjects(in: realm!).count, 1)
+        XCTAssertEqual(Employee.allObjects(in: realm!).count, 3)
+        
+        let companyStub = CompanyStub()
+        companyStub.employees = []
+        companyStub.uuid = original.uuid!
+        var jsonObj = companyStub.generateJsonObject()
+        XCTAssertEqual(jsonObj["employees"] as! NSArray, [])    // Sanity check.
+        
+        jsonObj["employees"] = NSNull()
+        XCTAssertEqual(jsonObj["employees"] as! NSNull, NSNull())    // Sanity check.
+        
+        let json = try! JSONValue(object: jsonObj)
+        
+        let mapping = CompanyMappingReplaceNullable(adapter: self.adapter!)
+        let mapper = Mapper()
+        
+        let spec = Binding.mapping("", mapping)
+        let company: Company = try! mapper.map(from: json, using: spec)
+        let employees = company.employees
+        
+        XCTAssertEqual(original.uuid, company.uuid)
+        XCTAssertEqual(Employee.allObjects(in: realm!).count, 1)
+        XCTAssertEqual(employees.count, 0)
+    }
+    
+    func testAssigningNullToCollectionWhenAppendNullableDoesNothing() {
+        class CompanyMappingAppendNullable: CompanyMapping {
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: self.adapter)
+                map(toRLMArray: toMap.employees,
+                    using: (.collectionMapping("employees", employeeMapping, (.append, true, true)), context))
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let dupEmployeeStub = EmployeeStub()
+        
+        let original = Company()
+        let originalEmployee = Employee()
+        let dupEmployee = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        dupEmployee.uuid = dupEmployeeStub.uuid
+        original.employees.append(originalEmployee)
+        original.employees.append(dupEmployee)
+        
+        try! self.adapter!.save(objects: [ original ])
+        XCTAssertEqual(Company.allObjects(in: realm!).count, 1)
+        XCTAssertEqual(Employee.allObjects(in: realm!).count, 2)
+        
+        let companyStub = CompanyStub()
+        companyStub.employees = []
+        companyStub.uuid = original.uuid!
+        var jsonObj = companyStub.generateJsonObject()
+        XCTAssertEqual(jsonObj["employees"] as! NSArray, [])    // Sanity check.
+        
+        jsonObj["employees"] = NSNull()
+        XCTAssertEqual(jsonObj["employees"] as! NSNull, NSNull())    // Sanity check.
+        
+        let json = try! JSONValue(object: jsonObj)
+        
+        let mapping = CompanyMappingAppendNullable(adapter: self.adapter!)
+        let mapper = Mapper()
+        
+        let spec = Binding.mapping("", mapping)
+        let company: Company = try! mapper.map(from: json, using: spec)
+        let employees = company.employees
+        
+        XCTAssertEqual(employees.count, 2)
+        XCTAssertEqual(original.uuid, company.uuid)
+        XCTAssertEqual(Company.allObjects(in: realm!).count, 1)
+        XCTAssertEqual(Employee.allObjects(in: realm!).count, 2)
+    }
+    
+    func testAssigningNullToCollectionWhenNonNullableThrows() {
+        class CompanyMappingAppendNonNullable: CompanyMapping {
+            override func mapping(toMap: inout Company, context: MappingContext) {
+                let employeeMapping = EmployeeMapping(adapter: self.adapter)
+                map(toRLMArray: toMap.employees,
+                    using: (.collectionMapping("employees", employeeMapping, (.append, true, false)), context))
+            }
+        }
+        
+        let uuid = NSUUID().uuidString
+        let dupEmployeeStub = EmployeeStub()
+        
+        let original = Company()
+        let originalEmployee = Employee()
+        let dupEmployee = Employee()
+        original.uuid = uuid
+        originalEmployee.uuid = uuid
+        dupEmployee.uuid = dupEmployeeStub.uuid
+        original.employees.append(originalEmployee)
+        original.employees.append(dupEmployee)
+        
+        try! self.adapter!.save(objects: [ original ])
+        XCTAssertEqual(Company.allObjects(in: realm!).count, 1)
+        XCTAssertEqual(Employee.allObjects(in: realm!).count, 2)
+        
+        let companyStub = CompanyStub()
+        companyStub.employees = []
+        companyStub.uuid = original.uuid!
+        var jsonObj = companyStub.generateJsonObject()
+        XCTAssertEqual(jsonObj["employees"] as! NSArray, [])    // Sanity check.
+        
+        jsonObj["employees"] = NSNull()
+        XCTAssertEqual(jsonObj["employees"] as! NSNull, NSNull())    // Sanity check.
+        
+        let json = try! JSONValue(object: jsonObj)
+        
+        let mapping = CompanyMappingAppendNonNullable(adapter: self.adapter!)
+        let mapper = Mapper()
+        
+        let spec = Binding.mapping("", mapping)
+        let testFunc = {
+            let _: Company = try mapper.map(from: json, using: spec)
+        }
+        
+        XCTAssertThrowsError(try testFunc())
+        XCTAssertEqual(Company.allObjects(in: realm!).count, 1)
+        XCTAssertEqual(Employee.allObjects(in: realm!).count, 2)
     }
 }

--- a/RealmCrustTests/Company.swift
+++ b/RealmCrustTests/Company.swift
@@ -16,7 +16,7 @@ public class CompanyMapping : RealmMapping {
     public func mapping(toMap: inout Company, context: MappingContext) {
         let employeeMapping = EmployeeMapping(adapter: self.adapter)
         
-        toMap.employees             <- (Binding.collectionMapping("employees", employeeMapping, (.append, true)), context)
+        toMap.employees             <- (Binding.collectionMapping("employees", employeeMapping, (.append, true, false)), context)
         toMap.founder               <- .mapping("founder", employeeMapping) >*< context
         toMap.name                  <- "name" >*<
         toMap.foundingDate          <- "data.founding_date"  >*<
@@ -30,8 +30,8 @@ public class CompanyMappingWithDupes : CompanyMapping {
     public override func mapping(toMap: inout Company, context: MappingContext) {
         let employeeMapping = EmployeeMapping(adapter: self.adapter)
         
-        toMap.employees <- (.collectionMapping("employees", employeeMapping, (.append, false)), context)
-        toMap.founder               <- .mapping("founder", employeeMapping) >*<
+        toMap.employees             <- (.collectionMapping("employees", employeeMapping, (.append, false, false)), context)
+        toMap.founder               <- Binding.mapping("founder", employeeMapping) >*<
         toMap.uuid                  <- "data.uuid" >*<
         toMap.name                  <- "name" >*<
         toMap.foundingDate          <- "data.founding_date"  >*<


### PR DESCRIPTION
* Allows Collections to accept "null" json values. Since there are types of collections which can never be optional (RLMArray specifically) _also_ in GraphQL "null" shouldn't even be expected with a NonNullable type, we rely on a `nullable` parameter in the `CollectionUpdatePolicy` to define whether or not a "null" value is even allowed.

* Allows Optional Collections to be usable in the first place (before, every collection had to be non-optional).

There's a table added to the README that defines all the cases that handled for `nullable`.